### PR TITLE
>>. operator

### DIFF
--- a/src/FSharp.Monad/Continuation.fs
+++ b/src/FSharp.Monad/Continuation.fs
@@ -42,3 +42,4 @@ module Continuation =
     let inline lift2 f a b = mreturn f <*> a <*> b
     let inline ( *>) x y = lift2 (fun _ z -> z) x y
     let inline ( <*) x y = lift2 (fun z _ -> z) x y
+    let inline (>>.) m f = cont.Bind(m, fun _ -> f)

--- a/src/FSharp.Monad/Maybe.fs
+++ b/src/FSharp.Monad/Maybe.fs
@@ -35,3 +35,4 @@ module Maybe =
     let inline lift2 f a b = mreturn f <*> a <*> b
     let inline ( *>) x y = lift2 (fun _ z -> z) x y
     let inline ( <*) x y = lift2 (fun z _ -> z) x y
+    let inline (>>.) m f = maybe.Bind(m, fun _ -> f)

--- a/src/FSharp.Monad/Reader.fs
+++ b/src/FSharp.Monad/Reader.fs
@@ -45,3 +45,4 @@ module Reader =
     let inline lift2 f a b = mreturn f <*> a <*> b
     let inline ( *>) x y = lift2 (fun _ z -> z) x y
     let inline ( <*) x y = lift2 (fun z _ -> z) x y
+    let inline (>>.) m f = reader.Bind(m, fun _ -> f)

--- a/src/FSharp.Monad/State.fs
+++ b/src/FSharp.Monad/State.fs
@@ -46,3 +46,4 @@ module State =
     let inline lift2 f a b = mreturn f <*> a <*> b
     let inline ( *>) x y = lift2 (fun _ z -> z) x y
     let inline ( <*) x y = lift2 (fun z _ -> z) x y
+    let inline (>>.) m f = state.Bind(m, fun _ -> f)

--- a/src/FSharp.Monad/Writer.fs
+++ b/src/FSharp.Monad/Writer.fs
@@ -58,3 +58,4 @@ module Writer =
     let inline lift2 f a b = mreturn f <*> a <*> b
     let inline ( *>) x y = lift2 (fun _ z -> z) x y
     let inline ( <*) x y = lift2 (fun z _ -> z) x y
+    let inline (>>.) m f = writer.Bind(m, fun _ -> f)


### PR DESCRIPTION
Added a >>. operator, which works like Haskell's >> ( http://haskell.org/ghc/docs/latest/html/libraries/base/Control-Monad.html#v:-62--62- ), useful for sequencing actions only for their side-effects.
