### PR TITLE
Added Async extension: TryAwaitTask

### DIFF
--- a/src/FSharpx.Async/sig.fsi
+++ b/src/FSharpx.Async/sig.fsi
@@ -102,6 +102,11 @@ namespace FSharp.Control
       static member Cache : input:Async<'T> -> Async<'T>
     type Async with
       static member StartDisposable : op:Async<unit> -> System.IDisposable
+    type Async with
+      static member
+        TryAwaitTask : task:System.Threading.Tasks.Task<'a> * ?timeout:int *
+                       ?cancellationToken:System.Threading.CancellationToken ->
+                         Async<'a option>
   end
 
 namespace FSharp.Control


### PR DESCRIPTION
Added an Async extension for TryAwaitTask: This returns an option type based on sucessful completion.

/// Starts a Task<'a> with the timeout and cancellationToken and
/// returns a Async<a' option> containing the result.  If the Task does
/// not complete in the timeout interval, or is faulted None is returned.  

TryAwaitTask : task:System.Threading.Tasks.Task<'a> \* ?timeout:int *
                       ?cancellationToken:System.Threading.CancellationToken ->
                         Async<'a option>
