### PR TITLE
Fix Iteratee.Binary.enumStream

### DIFF
--- a/src/FSharpx.Core/Iteratee.fs
+++ b/src/FSharpx.Core/Iteratee.fs
@@ -582,7 +582,7 @@ module Iteratee =
             and read k =
                 let result = stream.Read(buffer, 0, bufferSize) in
                 if result = 0 then Continue k
-                else step (k (Chunk(BS(buffer,0,buffer.Length))))
+                else step (k (Chunk(BS(buffer,0,result))))
             step i
 
         let enumStreamReader (reader:#System.IO.TextReader) i =


### PR DESCRIPTION
``` F#
let testIt count i =
    iteratee {
                let r = i <| take count
                return! r
             }

let main() =
    use stm = (new IO.MemoryStream()) :> IO.Stream
    stm.WriteByte 0x01uy
    stm.WriteByte 0x02uy // put 2 bytes into stream
    stm.Seek(0L, IO.SeekOrigin.Begin) |> ignore

    // create enumerator with 1kB buffer
    let en = enumStream 1024 stm
    printf "%A" (testIt 3 en)  // try to read 3 bytes

```

In this test, we put 2 bytes into stream and later trying to read 3 bytes. Function `testIt` should return `Contunue ...` but in current implementation of `enumStream` it returns `Done (seq [1uy; 2uy; 0uy]`.
Correct me, if I'm wrong.
