### PR TITLE
Naming

### DIFF
--- a/src/FSharpx.Core/CSharpCompat.fs
+++ b/src/FSharpx.Core/CSharpCompat.fs
@@ -387,7 +387,7 @@ type Dictionary =
   static member TryFind (d, key) = Dictionary.tryFind key d
 
 [<Extension>]
-type FSharpAsyncExtensions =
+type FSharpAsyncEx =
     [<Extension>]
     static member SelectMany (o, f: Func<_,_>) = 
         Async.bind f.Invoke o

--- a/tests/FSharpx.CSharpTests/AsyncTests.cs
+++ b/tests/FSharpx.CSharpTests/AsyncTests.cs
@@ -52,8 +52,8 @@ namespace FSharpx.CSharpTests {
             // super verbose return
             FSharpAsync<int> i = ExtraTopLevelOperators.DefaultAsyncBuilder.Return(1);
 
-            FSharpAsync<int> x = FSharpAsyncExtensions.Return(1);
-            FSharpAsync<Func<int>> fa = FSharpAsyncExtensions.Return(L.F(() => 1));
+            FSharpAsync<int> x = FSharpAsyncEx.Return(1);
+            FSharpAsync<Func<int>> fa = FSharpAsyncEx.Return(L.F(() => 1));
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace FSharpx.CSharpTests {
                 , "http://www.microsoft.com"
                 );
             var realJoinWebPages = JoinWebPages(url => Get(url).Protect());
-            var testJoinWebPages = JoinWebPages(_ => FSharpAsyncExtensions.Return(FSharpChoice.New1Of2<string, Exception>("hello")));
+            var testJoinWebPages = JoinWebPages(_ => FSharpAsyncEx.Return(FSharpChoice.New1Of2<string, Exception>("hello")));
             var result = testJoinWebPages(urls);
             Assert.AreEqual("hellohellohellohello", result);
         }


### PR DESCRIPTION
I suck at naming stuff.
I needed a shortcut for async.Return, which I named AsyncReturn() (it's an extension method).
Also there's a function that turns a Func into an Async (via Begin/End), I called that ToFSharpAsync() (also an ext.method).
Does this look good to you? Any better naming?
