### PR TITLE
Add toArray and update the toList extensions on NameValueCollection.

### DIFF
--- a/src/FSharpx.Core/Collections.fs
+++ b/src/FSharpx.Core/Collections.fs
@@ -583,6 +583,17 @@ module NameValueCollection =
         r
 
     /// <summary>
+    /// Returns a <see cref="NameValueCollection"/> as an array of key-value pairs.
+    /// Note that keys may be duplicated.
+    /// </summary>
+    /// <param name="a"></param>
+    [<Extension>]
+    [<CompiledName("ToArray")>]
+    let toArray (a: NameValueCollection) =
+        a.AllKeys
+        |> Array.collect (fun k -> a.GetValues k |> Array.map (fun v -> k,v))
+
+    /// <summary>
     /// Returns a <see cref="NameValueCollection"/> as a sequence of key-value pairs.
     /// Note that keys may be duplicated.
     /// </summary>

--- a/tests/FSharpx.Tests/NameValueCollectionTests.fs
+++ b/tests/FSharpx.Tests/NameValueCollectionTests.fs
@@ -24,6 +24,20 @@ let toSeq() =
   Assert.AreEqual(r,s)
 
 [<Test>]
+let toArray() =
+  let r = [|"1","uno"; "1","one"; "2","two"|]
+  let a = NameValueCollection.fromSeq r
+  let s = NameValueCollection.toArray a
+  Assert.AreEqual(r,s)
+  
+[<Test>]
+let toList() =
+  let r = ["1","uno"; "1","one"; "2","two"]
+  let a = NameValueCollection.fromSeq r
+  let s = NameValueCollection.toList a
+  Assert.AreEqual(r,s)
+
+[<Test>]
 let concat() =
   let a = NameValueCollection()
   a.Add("1", "uno")


### PR DESCRIPTION
This is not the same as suggested on the list. I realized I had misunderstood these methods. This commit adds a `toArray` function and tests for `toArray` and `toList`.
