### PR TITLE
New Constructor Option for JSON and XML Type Providers

### DIFF
--- a/src/FSharpx.TypeProviders/Inference.fs
+++ b/src/FSharpx.TypeProviders/Inference.fs
@@ -5,6 +5,7 @@
 module FSharpx.TypeProviders.Inference
 
 open System
+open System.Xml
 open System.Xml.Linq
 open FSharpx.TypeProviders.DSL
 open System.Collections.Generic
@@ -103,6 +104,7 @@ type GeneratedParserSettings = {
     Schema: CompoundProperty
     EmptyConstructor: ExprDef
     FileNameConstructor: ExprDef
+    DocumentContentConstructor : ExprDef
     RootPropertyGetter: ExprDef
     ToStringExpr: ExprDef }
 
@@ -114,6 +116,8 @@ let createParserType<'a> typeName (generateTypeF: ProvidedTypeDefinition -> Comp
            |> addXmlDoc "Initializes the document from the schema sample.")
     |+!> (provideConstructor ["filename", typeof<string>] settings.FileNameConstructor
            |> addXmlDoc "Initializes a document from the given path.")
+    |+!> (provideConstructor ["documentContent", typeof<string>] settings.DocumentContentConstructor
+           |> addXmlDoc "Initializes a document from the given JSON string.")
     |+!> (provideProperty "Root" (generateTypeF parserType settings.Schema) settings.RootPropertyGetter
            |> addXmlDoc "Gets the document root")
     |+!> (provideMethod ("ToString") [] typeof<string> settings.ToStringExpr

--- a/src/FSharpx.TypeProviders/JsonProvider.fs
+++ b/src/FSharpx.TypeProviders/JsonProvider.fs
@@ -77,6 +77,7 @@ let jsonType (ownerType:TypeProviderForNamespaces) cfg =
         { Schema = JSONInference.provideElement "Document" false [parse jsonText]
           EmptyConstructor = fun args -> <@@ parse jsonText @@>
           FileNameConstructor = fun args -> <@@ (%%args.[0] : string) |> File.ReadAllText |> parse  @@>
+          DocumentContentConstructor = fun args -> <@@ (%%args.[0] : string) |> parse  @@>
           RootPropertyGetter = fun args -> <@@ (%%args.[0] : Document) @@>
           ToStringExpr = fun args -> <@@ (%%args.[0]: Document).ToString() @@> }
         |> createParserType<Document> typeName generateType            

--- a/src/FSharpx.TypeProviders/XmlProvider.fs
+++ b/src/FSharpx.TypeProviders/XmlProvider.fs
@@ -74,6 +74,7 @@ let xmlType (ownerType:TypeProviderForNamespaces) cfg =
         { Schema = XmlInference.provideElement doc.Root.Name.LocalName [doc.Root]
           EmptyConstructor = fun args -> <@@ TypedXDocument(XDocument.Parse xmlText) @@>
           FileNameConstructor = fun args -> <@@ TypedXDocument(XDocument.Load(%%args.[0] : string)) @@>
+          DocumentContentConstructor = fun args -> <@@ TypedXDocument(XDocument.Parse(%%args.[0] : string)) @@>
           RootPropertyGetter = fun args -> <@@ TypedXElement((%%args.[0] : TypedXDocument).Document.Root) @@>
           ToStringExpr = fun args -> <@@ (%%args.[0]: TypedXDocument).Document.ToString() @@> }
         |> createParserType<TypedXDocument> typeName generateType            

--- a/tests/FSharpx.TypeProviders.Tests/FSharpx.TypeProviders.Tests.fsproj
+++ b/tests/FSharpx.TypeProviders.Tests/FSharpx.TypeProviders.Tests.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="FileSystem.Tests.fs" />
     <Compile Include="Xml.Reader.Tests.fs" />
     <Compile Include="Xml.Writer.Tests.fs" />
+    <Compile Include="Xml.DocumentOverride.Tests.fs" />
     <Compile Include="JSON.Parser.Tests.fs" />
     <Compile Include="JSON.Equality.Tests.fs" />
     <Compile Include="JSON.Serialization.Tests.fs" />
@@ -52,6 +53,7 @@
     <Compile Include="JSON.Reader.Tests.fs" />
     <Compile Include="JSON.Writer.Tests.fs" />
     <Compile Include="JSON.WikiSample.Tests.fs" />
+    <Compile Include="JSON.DocumentOverride.Tests.fs" />
     <Compile Include="Regex.Tests.fs" />
     <Compile Include="Vector.Tests.fs" />
     <Compile Include="AppSettings.Tests.fs" />

--- a/tests/FSharpx.TypeProviders.Tests/JSON.DocumentOverride.Tests.fs
+++ b/tests/FSharpx.TypeProviders.Tests/JSON.DocumentOverride.Tests.fs
@@ -1,0 +1,55 @@
+﻿module FSharpx.TypeProviders.Tests.JSON.DocumentOverride.Tests
+
+open NUnit.Framework
+open FSharpx
+open FsUnit
+open System.Xml
+
+type WikiSample =
+    StructuredJSON<Schema=
+        """{  
+                 "firstName": "John",
+                 "lastName" : "Smith",
+                 "age"      : 25
+           }""">
+
+let newJson = 
+    """{  
+            "firstName": "Jane",
+            "lastName" : "Doe",
+            "age"      : 23
+    }"""
+
+let newJson2 = 
+    """{  
+            "firstName": "Jim",
+            "lastName" : "Smith",
+            "age"      : 24
+    }"""
+
+let document = WikiSample(documentContent=newJson).Root
+let document2 = WikiSample(documentContent=newJson2).Root
+
+[<Test>]
+let ``Jane should have first name of Jane``() = 
+    document.FirstName |> should equal "Jane"
+
+[<Test>]
+let ``Jane should have a last name of Doe``() = 
+    document.LastName |> should equal "Doe"
+
+[<Test>]
+let ``Jane should have an age of 23``() = 
+    document.Age |> should equal 23
+
+[<Test>]
+let ``Jim should have a first name of Jim``() = 
+    document2.FirstName |> should equal "Jim"
+
+[<Test>]
+let ``Jim should have a last name of Smith``() = 
+    document2.LastName |> should equal "Smith"
+
+[<Test>]
+let ``Jim should have an age of 24``() = 
+    document2.Age |> should equal 24

--- a/tests/FSharpx.TypeProviders.Tests/JSON.Reader.Tests.fs
+++ b/tests/FSharpx.TypeProviders.Tests/JSON.Reader.Tests.fs
@@ -23,7 +23,7 @@ let ``Can parse inlined properties``() =
 
 [<Test>]
 let ``Can parse inlined properties but read from file``() = 
-    let inlined = InlinedJSON("Simple.json").Root
+    let inlined = InlinedJSON(filename="Simple.json").Root
     inlined.FirstName
     |> should equal "John"
 

--- a/tests/FSharpx.TypeProviders.Tests/JSON.WikiSample.Tests.fs
+++ b/tests/FSharpx.TypeProviders.Tests/JSON.WikiSample.Tests.fs
@@ -40,7 +40,7 @@ let ``Can parse wiki sample``() =
 
 [<Test>]
 let ``Can load and manipulate wiki data``() = 
-    let document = WikiSample("WikiData.json").Root
+    let document = WikiSample(filename="WikiData.json").Root
     document.FirstName |> should equal "John"
     document.LastName |> should equal "Doe"
 
@@ -53,7 +53,7 @@ let ``Can load and manipulate wiki data``() =
 
 [<Test>]
 let ``Can load empty json file and fails on property access``() = 
-    let document = WikiSample("Empty.json").Root
+    let document = WikiSample(filename="Empty.json").Root
     let failed = ref false
     try
         document.FirstName |> ignore

--- a/tests/FSharpx.TypeProviders.Tests/Xml.DocumentOverride.Tests.fs
+++ b/tests/FSharpx.TypeProviders.Tests/Xml.DocumentOverride.Tests.fs
@@ -1,0 +1,38 @@
+﻿module FSharpx.TypeProviders.Tests.Xml.DocumentOverride.Tests
+
+open NUnit.Framework
+open FSharpx
+open FsUnit
+open System.Xml
+
+type PersonXml = StructuredXml<Schema="""<authors><author name="Ludwig" surname="Wittgenstein" age="29" /></authors>""">
+
+let newXml = """<authors><author name="Jane" surname="Doe" age="23" /></authors>"""
+let newXml2 = """<authors><author name="Jim" surname="Smith" age="24" /></authors>"""
+
+let firstPerson = PersonXml(documentContent=newXml).Root.GetAuthors() |> Seq.head
+let nextPerson = PersonXml(documentContent=newXml2).Root.GetAuthors() |> Seq.head
+
+[<Test>]
+let ``Jane should have first name of Jane``() = 
+    firstPerson.Name |> should equal "Jane"
+
+[<Test>]
+let ``Jane should have a last name of Doe``() = 
+    firstPerson.Surname |> should equal "Doe"
+
+[<Test>]
+let ``Jane should have an age of 23``() = 
+    firstPerson.Age |> should equal 23
+
+[<Test>]
+let ``Jim should have a first name of Jim``() = 
+    nextPerson.Name |> should equal "Jim"
+
+[<Test>]
+let ``Jim should have a last name of Smith``() = 
+    nextPerson.Surname |> should equal "Smith"
+
+[<Test>]
+let ``Jim should have an age of 24``() = 
+    nextPerson.Age |> should equal 24


### PR DESCRIPTION
Added a new constructor for the JSON and XML type providers to allow a string representation of the document to be passed in at runtime.
