### PR TITLE
Add missing pattern matches in Observable.combineLatest

### DIFF
--- a/src/FSharpx.Core/Observable.fs
+++ b/src/FSharpx.Core/Observable.fs
@@ -143,11 +143,13 @@ module Observable =
       Observable.merge left right
       |> Observable.scan (fun (_,(l',r')) (l,r) ->
           match l,r,l',r' with
-          | Some lv, None, _, Some rv ->
-              Some(lv,rv), (l,r')
-          | None, Some rv, Some lv, _ ->
-              Some(lv,rv), (l',r)
-          | _, _, _,_ -> invalidOp "Invalid state"
+          | Some lv, None,    _,       Some rv -> Some(lv,rv), (l,r')
+          | None,    Some rv, Some lv, _       -> Some(lv,rv), (l',r)
+          | Some _,  _,       _,       None    -> None,        (l, r')
+          | _,       Some _,  None,    _       -> None,        (l', r)
+          | None,    None,    _,       _       -> None,        (l', r')
+          | Some _,  Some _,  _,       _ -> 
+                invalidOp "Should not receive both left and right"
       ) (None, (None,None))
       |> Observable.choose fst
 


### PR DESCRIPTION
The current implementation of Observable.combineLatest has no valid match for a state of (_, (None, None)), which is the initial state.  It therefore immediately throws invalidOp. This version should correctly accumulate Left/Right values until both a left and a right are available.

(I am new to "pull requests"; please let me know if I ought to do this differently.)
