### PR TITLE
Fix Iteratee.bind

### DIFF
--- a/src/FSharpx.Core/Iteratee.fs
+++ b/src/FSharpx.Core/Iteratee.fs
@@ -175,6 +175,7 @@ module Iteratee =
 
     let bind f i =
         let inner bind = function
+            | Done(x, Empty) -> f x
             | Done(x, extra) ->
                 match f x with
                 | Done(x',_) -> Done(x', extra)


### PR DESCRIPTION
<a href="http://hackage.haskell.org/packages/archive/enumerator/0.4.4/doc/html/Data-Enumerator.html">Haskell implementation</a> of inner, which is an internal function of Iteratee.bind

<pre>
case r1 of
    Continue k -> return (Continue (bind . k))
    Error err -> return (Error err)
    Yield x (Chunks []) -> runIteratee (f x)
    Yield x extra -> runIteratee (f x) >>= \r2 ->
        case r2 of  ...
</pre>


Done(x, Chunk Empty) pattarn has not been implemented in the current implementation.
