### PR TITLE
3 new queues, 1 test module for queues

### DIFF
--- a/src/FSharpx.Core/DataStructures/BankersQueue.fs
+++ b/src/FSharpx.Core/DataStructures/BankersQueue.fs
@@ -1,0 +1,164 @@
+﻿//originally published by Julien
+// original implementation taken from http://lepensemoi.free.fr/index.php/2009/12/31/bankers-queue
+
+//jf -- added ofSeq and try...
+//pattern discriminators Snoc and Nil
+
+namespace FSharpx.DataStructures
+
+open LazyListHelpr
+open System.Collections
+open System.Collections.Generic
+
+type BankersQueue<'a> (frontLength : int, front : LazyList<'a>, backLength : int, back : LazyList<'a>) = 
+
+    member private this.frontLength = frontLength
+
+    member internal this.front = front
+
+    member private this.backLength = backLength
+
+    member internal this.back = back
+
+    static member private check (q : BankersQueue<'a>) =
+        if q.backLength <= q.frontLength
+        then q
+        else BankersQueue((q.backLength + q.frontLength), (LazyList.append q.front (lLrev q.back)), 0, LazyList.empty)
+
+    static member private length (q : BankersQueue<'a>) = q.frontLength + q.backLength
+
+    static member internal Empty() = new BankersQueue<'a>(0, LazyList.empty, 0, LazyList.empty) 
+
+    static member internal OfSeq (xs:seq<'a>) = 
+        BankersQueue<'a>((Seq.length xs), (LazyList.ofSeq xs), 0, LazyList.empty)
+   
+    ///returns the first element
+    member this.Head =
+        if (this.frontLength = 0)  
+        then raise Exceptions.Empty
+        else LazyList.head front
+
+    ///returns option first element
+    member this.TryGetHead =
+        if (this.frontLength = 0)  then None
+        else Some(LazyList.head front)
+         
+    ///returns true if the queue has no elements
+    member this.IsEmpty = (frontLength = 0)
+
+    ///returns the count of elememts
+    member this.Length = BankersQueue.length this
+
+    ///returns queue reversed
+    member this.Rev = BankersQueue<'a>(backLength, back, frontLength, front) |> BankersQueue.check
+
+    ///returns a new queue with the element added to the end
+    member this.Snoc x = 
+        BankersQueue<'a>(frontLength, front, (backLength + 1), (LazyList.cons x back))
+        |> BankersQueue.check
+
+    ///returns a new queue of the elements trailing the first element
+    member this.Tail =
+        if (this.frontLength = 0)  then raise Exceptions.Empty
+        else 
+            BankersQueue<'a>((frontLength-1), (LazyList.tail front), backLength, back)
+            |> BankersQueue.check
+
+    ///returns option queue of the elements trailing the first element
+    member this.TryGetTail =
+        if (this.frontLength = 0)  then None
+        else 
+            Some(BankersQueue<'a>((frontLength-1), (LazyList.tail front), backLength, back)
+            |> BankersQueue.check)
+
+    ///returns the first element and tail
+    member this.Uncons =  
+        if (this.frontLength = 0)  then raise Exceptions.Empty
+        else (LazyList.head front), (BankersQueue<'a>((frontLength - 1), (LazyList.tail front), backLength, back) |> BankersQueue.check)
+
+    ///returns option first element and tail
+    member this.TryUncons =  
+        if (this.frontLength = 0)  then None
+        else Some((LazyList.head front), (BankersQueue<'a>((frontLength-1), (LazyList.tail front), backLength, back) |> BankersQueue.check))
+
+    with
+    interface IQueue<'a> with
+
+        member this.Count = this.Length
+
+        member this.Head = this.Head
+
+        member this.TryGetHead = this.TryGetHead
+
+        member this.IsEmpty = this.IsEmpty
+
+        member this.Length = this.Length
+
+        member this.Snoc x = this.Snoc x :> _
+
+        member this.Tail = this.Tail :> _ 
+
+        member this.TryGetTail =
+            match this.TryGetTail with
+            | None -> None
+            | Some(q) -> Some(q :> _)
+
+        member this.Uncons = 
+            let x, xs = this.Uncons 
+            x, xs :> _
+
+        member this.TryUncons = 
+            match this.TryUncons with
+            | None -> None
+            | Some(x, q) -> Some(x, q :> _)
+          
+    interface IEnumerable<'a> with
+
+        member this.GetEnumerator() = 
+            let e = seq {
+                  yield! front
+                  yield! (lLrev back)  }
+            e.GetEnumerator()
+
+        member this.GetEnumerator() = (this :> _ seq).GetEnumerator() :> IEnumerator
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module BankersQueue =
+    //pattern discriminators
+    let (|Cons|Nil|) (q : BankersQueue<'a>) = match q.TryUncons with Some(a,b) -> Cons(a,b) | None -> Nil
+
+    ///returns queue of no elements
+    let empty() = BankersQueue.Empty()
+
+    ///returns the first element
+    let inline head (q : BankersQueue<'a>) = q.Head
+
+    ///returns option first element
+    let inline tryGetHead (q : BankersQueue<'a>) = q.TryGetHead
+
+    ///returns true if the queue has no elements
+    let inline isEmpty() (q : BankersQueue<'a>) = q.IsEmpty
+
+    ///returns the count of elememts
+    let inline length() (q : BankersQueue<'a>) = q.Length
+
+    ///returns a queue of the seq
+    let ofSeq xs = BankersQueue.OfSeq xs
+
+    ///returns queue reversed
+    let inline rev (q : BankersQueue<'a>) = q.Rev
+
+    ///returns a new queue with the element added to the end
+    let inline snoc (x : 'a) (q : BankersQueue<'a>) = (q.Snoc x) 
+
+    ///returns a new queue of the elements trailing the first element
+    let inline tail (q : BankersQueue<'a>) = q.Tail 
+
+    ///returns option queue of the elements trailing the first element
+    let inline tryGetTail (q : BankersQueue<'a>) = q.TryGetTail 
+
+    ///returns the first element and tail
+    let inline uncons (q : BankersQueue<'a>) = q.Uncons
+
+    ///returns option first element and tail
+    let inline tryUncons (q : BankersQueue<'a>) = q.TryUncons

--- a/src/FSharpx.Core/DataStructures/BatchedQueue.fs
+++ b/src/FSharpx.Core/DataStructures/BatchedQueue.fs
@@ -1,0 +1,184 @@
+﻿//originally published by Julien
+// original implementation taken from http://lepensemoi.free.fr/index.php/2009/12/10/batched-queue
+
+//jf -- added ofSeq and try...
+//pattern discriminators Snoc and Nil
+
+namespace FSharpx.DataStructures
+
+open System.Collections
+open System.Collections.Generic
+
+type BatchedQueue<'a> (front : list<'a>, rBack : list<'a>) = 
+
+    member internal this.front = front
+
+    member internal this.rBack = rBack
+
+    static member private checkf (q : BatchedQueue<'a>) =
+        match q.front, q.rBack with
+        | [], r -> BatchedQueue((List.rev r), [])
+        | f, r -> BatchedQueue(f, r)
+
+    static member private length (q : BatchedQueue<'a>) = q.front.Length + q.rBack.Length
+
+    static member internal Empty : BatchedQueue<'a> = BatchedQueue<'a>([], []) 
+
+    static member internal fold (f : ('State -> 'T -> 'State)) (state : 'State) (q : BatchedQueue<'T>)  :  'State = 
+        let s = List.fold f state q.front
+        List.fold f s (List.rev q.rBack)
+
+    static member internal foldBack (f : ('T -> 'State -> 'State)) (q : BatchedQueue<'T>) (state : 'State) :  'State = 
+        let s = List.foldBack f (List.rev q.rBack) state 
+        (List.foldBack f q.front s)
+
+    static member internal OfList (xs:list<'a>) = 
+        BatchedQueue<'a>(xs, [])
+
+    static member internal OfSeq (xs:seq<'a>) = 
+        BatchedQueue<'a>((List.ofSeq xs), [])
+
+    ///returns the first element
+    member this.Head = 
+        match front with
+        | hd::_ -> hd
+        | _ -> raise Exceptions.Empty
+
+    ///returns option first element
+    member this.TryGetHead =
+        match front with
+        | hd::_ -> Some(hd)
+        | _ -> None
+         
+    ///returns true if the queue has no elements
+    member this.IsEmpty = front.IsEmpty
+
+    ///returns the count of elememts
+    member this.Length = BatchedQueue.length this
+
+    ///returns queue reversed
+    member this.Rev = 
+        BatchedQueue<'a>(rBack, front) |> BatchedQueue.checkf
+
+    ///returns a new queue with the element added to the end
+    member this.Snoc x = 
+        BatchedQueue<'a>(front, x::rBack)
+        |> BatchedQueue.checkf
+
+    ///returns a new queue of the elements trailing the first element
+    member this.Tail =
+        match front with
+        | hd::tl -> 
+            BatchedQueue<'a>(tl, rBack)
+            |> BatchedQueue.checkf
+        | _ -> raise Exceptions.Empty
+            
+    ///returns option queue of the elements trailing the first element
+    member this.TryGetTail =
+        match front with
+        | hd::tl -> Some(BatchedQueue<'a>(tl, rBack) |> BatchedQueue.checkf)
+        | _ -> None
+
+    ///returns the first element and tail
+    member this.Uncons =  
+        match front with
+        | hd::tl -> hd, (BatchedQueue<'a>(tl, rBack) |> BatchedQueue.checkf)
+        | _ -> raise Exceptions.Empty
+
+    ///returns option first element and tail
+    member this.TryUncons =  
+        match front with
+        | hd::tl -> Some(hd, (BatchedQueue<'a>(tl, rBack) |> BatchedQueue.checkf))
+        | _ -> None
+
+    with
+    interface IQueue<'a> with
+
+        member this.Count = this.Length
+
+        member this.Head = this.Head
+
+        member this.TryGetHead = this.TryGetHead
+
+        member this.IsEmpty = this.IsEmpty
+
+        member this.Length = this.Length
+
+        member this.Snoc x = this.Snoc x :> _
+
+        member this.Tail = this.Tail :> _
+
+        member this.TryGetTail = 
+            match this.TryGetTail with
+            | None -> None
+            | Some(q) -> Some(q :> _)
+
+        member this.Uncons = 
+            let x, xs = this.Uncons 
+            x, xs :> _
+
+        member this.TryUncons = 
+            match this.TryUncons with
+            | None -> None
+            | Some(x, q) -> Some(x, q :> _)
+          
+    interface IEnumerable<'a> with
+
+        member this.GetEnumerator() = 
+            let e = seq {
+                  yield! front
+                  yield! (List.rev rBack)}
+            e.GetEnumerator()
+
+        member this.GetEnumerator() = (this :> _ seq).GetEnumerator() :> IEnumerator
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module BatchedQueue =
+    //pattern discriminators
+    let (|Cons|Nil|) (q : BatchedQueue<'a>) = match q.TryUncons with Some(a,b) -> Cons(a,b) | None -> Nil
+
+    ///returns queue of no elements
+    ///c is front-back stream ration constant, should be at least 2
+    let empty() : BatchedQueue<'a> = BatchedQueue.Empty
+
+    ///applies a function to each element of the queue, threading an accumulator argument through the computation, left to right
+    let fold (f : ('State -> 'T -> 'State)) (state : 'State) (q : BatchedQueue<'T>) = BatchedQueue<_>.fold f state q
+
+    ///applies a function to each element of the queue, threading an accumulator argument through the computation, right to left
+    let foldBack (f : ('T -> 'State -> 'State)) (q : BatchedQueue<'T>) (state : 'State) =  BatchedQueue<_>.foldBack f q state
+
+    ///returns the first element
+    let inline head (q : BatchedQueue<'a>) = q.Head
+
+    ///returns option first element
+    let inline tryGetHead (q : BatchedQueue<'a>) = q.TryGetHead
+
+    ///returns true if the queue has no elements
+    let inline isEmpty (q : BatchedQueue<'a>) = q.IsEmpty
+
+    ///returns the count of elememts
+    let inline length (q : BatchedQueue<'a>) = q.Length
+
+    ///returns a queue of the list
+    let ofList xs = BatchedQueue.OfList xs
+
+    ///returns a queue of the seq
+    let ofSeq xs = BatchedQueue.OfSeq xs
+
+    ///returns queue reversed
+    let inline rev (q : BatchedQueue<'a>) = q.Rev
+
+    ///returns a new queue with the element added to the end
+    let inline snoc (x : 'a) (q : BatchedQueue<'a>) = (q.Snoc x) 
+
+    ///returns a new queue of the elements trailing the first element
+    let inline tail (q : BatchedQueue<'a>) = q.Tail 
+
+    ///returns option queue of the elements trailing the first element
+    let inline tryGetTail (q : BatchedQueue<'a>) = q.TryGetTail 
+
+    ///returns the first element and tail
+    let inline uncons (q : BatchedQueue<'a>) = q.Uncons
+
+    ///returns option first element and tail
+    let inline tryUncons (q : BatchedQueue<'a>) = q.TryUncons

--- a/src/FSharpx.Core/DataStructures/PhysicistQueue.fs
+++ b/src/FSharpx.Core/DataStructures/PhysicistQueue.fs
@@ -1,0 +1,206 @@
+﻿//originally published by Julien
+// original implementation taken from http://lepensemoi.free.fr/index.php/2009/12/31/physicist-queue
+
+//jf -- added ofSeq and try...
+//pattern discriminators Snoc and Nil
+
+namespace FSharpx.DataStructures
+
+open System.Collections
+open System.Collections.Generic
+ 
+type PhysicistQueue<'a> (prefix : list<'a>, frontLength : int, front : Lazy<list<'a>>, rBackLength : int, rBack : list<'a>) = 
+
+    member internal this.prefix = prefix
+
+    member private this.frontLength = frontLength
+
+    member internal this.front = front
+
+    member private this.rBackLength = rBackLength
+
+    member internal this.rBack = rBack
+
+    static member private checkw (q : PhysicistQueue<'a>) =
+        match q.prefix with
+        | [] -> PhysicistQueue(q.front.Value, q.frontLength, q.front, q.rBackLength, q.rBack)
+        | _ -> q
+
+    static member private check (q : PhysicistQueue<'a>) =
+        if q.rBackLength <= q.frontLength then
+            PhysicistQueue.checkw q
+        else
+            PhysicistQueue(q.front.Value, (q.frontLength + q.rBackLength),  (lazy (q.rBack |> List.rev |> List.append q.front.Value)), 0, [])
+            |> PhysicistQueue.checkw
+
+    static member private length (q : PhysicistQueue<'a>) = q.frontLength + q.rBackLength
+
+    static member internal Empty() = PhysicistQueue<'a>([], 0, lazy [], 0, []) 
+
+    static member internal fold (f : ('State -> 'T -> 'State)) (state : 'State) (q : PhysicistQueue<'T>)  :  'State =        
+        let s = 
+             if (q.prefix.Length = q.frontLength)
+                then List.fold f state q.prefix
+                else List.fold f state q.front.Value
+
+        List.fold f s (List.rev q.rBack)
+
+    static member internal foldBack (f : ('T -> 'State -> 'State)) (q : PhysicistQueue<'T>) (state : 'State) :  'State = 
+        let s = List.foldBack f (List.rev q.rBack) state 
+
+        if (q.prefix.Length = q.frontLength)
+            then (List.foldBack f q.prefix s)
+            else (List.foldBack f q.front.Value s)
+
+    static member internal OfList (xs:list<'a>) = PhysicistQueue<'a>(xs, xs.Length, (lazy xs), 0, [])
+
+    static member internal OfSeq (xs:seq<'a>) = 
+        PhysicistQueue<'a>((List.ofSeq xs), (Seq.length xs), (lazy (List.ofSeq xs)), 0, [])
+   
+    ///returns the first element
+    member this.Head =
+        match prefix with
+        | hd::_ -> hd
+        | _ -> raise Exceptions.Empty
+
+    ///returns option first element
+    member this.TryGetHead =
+        match prefix with
+        | hd::_ -> Some(hd)
+        | _ -> None
+         
+    ///returns true if the queue has no elements
+    member this.IsEmpty = (frontLength = 0)
+
+    ///returns the count of elememts
+    member this.Length = PhysicistQueue.length this
+
+    ///returns queue reversed
+    member this.Rev = 
+        if (prefix.Length = frontLength)
+        then PhysicistQueue<'a>(rBack, rBackLength, (lazy rBack), frontLength, prefix) |> PhysicistQueue.check
+        else PhysicistQueue<'a>(rBack, rBackLength, (lazy rBack), frontLength, front.Value) |> PhysicistQueue.check
+
+    ///returns a new queue with the element added to the end
+    member this.Snoc x = 
+        PhysicistQueue(prefix, frontLength, front, (rBackLength + 1), x::rBack)
+        |> PhysicistQueue.check
+
+    ///returns a new queue of the elements trailing the first element
+    member this.Tail =
+        match prefix with
+        | hd::_ ->
+            PhysicistQueue(prefix.Tail, (frontLength - 1), (lazy front.Value.Tail), rBackLength, rBack)
+            |> PhysicistQueue.check
+        | _ -> raise Exceptions.Empty
+
+    ///returns option queue of the elements trailing the first element
+    member this.TryGetTail =
+        match prefix with
+        | hd::_ ->
+            Some (PhysicistQueue(prefix.Tail, (frontLength - 1), (lazy front.Value.Tail), rBackLength, rBack) |> PhysicistQueue.check)
+        | _ -> None
+
+    ///returns the first element and tail
+    member this.Uncons = 
+        match prefix with
+        | hd::_ -> hd, (PhysicistQueue(prefix.Tail, (frontLength - 1), (lazy front.Value.Tail), rBackLength, rBack) |> PhysicistQueue.check)
+        | _ -> raise Exceptions.Empty
+
+    ///returns option first element and tail
+    member this.TryUncons =  
+       match prefix with
+        | hd::_ -> Some(hd, (PhysicistQueue(prefix.Tail, (frontLength - 1), (lazy front.Value.Tail), rBackLength, rBack) |> PhysicistQueue.check))
+        | _ -> None
+
+    with
+    interface IQueue<'a> with
+
+        member this.Count = this.Length
+
+        member this.Head = this.Head
+
+        member this.TryGetHead = this.TryGetHead
+
+        member this.IsEmpty = this.IsEmpty
+
+        member this.Length = this.Length
+
+        member this.Snoc x = this.Snoc x :> _
+
+        member this.Tail = this.Tail :> _
+
+        member this.TryGetTail = 
+            match this.TryGetTail with
+            | None -> None
+            | Some(q) -> Some(q :> _)
+
+        member this.Uncons = 
+            let x, xs = this.Uncons 
+            x, xs :> _
+
+        member this.TryUncons = 
+            match this.TryUncons with
+            | None -> None
+            | Some(x, q) -> Some(x, q :> _)
+          
+    interface IEnumerable<'a> with
+
+        member this.GetEnumerator() = 
+            let e = seq {
+                  yield! front.Value
+                  yield! (List.rev rBack)}
+            e.GetEnumerator()
+
+        member this.GetEnumerator() = (this :> _ seq).GetEnumerator() :> IEnumerator
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module PhysicistQueue =
+    //pattern discriminators
+
+    let (|Cons|Nil|) (q : PhysicistQueue<'a>) = match q.TryUncons with Some(a,b) -> Cons(a,b) | None -> Nil
+
+    ///returns queue of no elements
+    let empty() = PhysicistQueue.Empty()
+
+    ///applies a function to each element of the queue, threading an accumulator argument through the computation, left to right
+    let fold (f : ('State -> 'T -> 'State)) (state : 'State) (q : PhysicistQueue<'T>) = PhysicistQueue<_>.fold f state q
+
+    ///applies a function to each element of the queue, threading an accumulator argument through the computation, right to left
+    let foldBack (f : ('T -> 'State -> 'State)) (q : PhysicistQueue<'T>) (state : 'State) =  PhysicistQueue<_>.foldBack f q state
+
+    ///returns the first element
+    let inline head (q : PhysicistQueue<'a>) = q.Head
+
+    ///returns option first element
+    let inline tryGetHead (q : PhysicistQueue<'a>) = q.TryGetHead
+
+    ///returns true if the queue has no elements
+    let inline isEmpty (q : PhysicistQueue<'a>) = q.IsEmpty
+
+    ///returns the count of elememts
+    let inline length (q : PhysicistQueue<'a>) = q.Length
+
+    ///returns a queue of the list
+    let ofList xs = PhysicistQueue.OfList xs
+
+    ///returns a queue of the seq
+    let ofSeq xs = PhysicistQueue.OfSeq xs
+
+    ///returns queue reversed
+    let inline rev (q : PhysicistQueue<'a>) = q.Rev
+
+    ///returns a new queue with the element added to the end
+    let inline snoc (x : 'a) (q : PhysicistQueue<'a>) = (q.Snoc x) 
+
+    ///returns a new queue of the elements trailing the first element
+    let inline tail (q : PhysicistQueue<'a>) = q.Tail 
+
+    ///returns option queue of the elements trailing the first element
+    let inline tryGetTail (q : PhysicistQueue<'a>) = q.TryGetTail 
+
+    ///returns the first element and tail
+    let inline uncons (q : PhysicistQueue<'a>) = q.Uncons
+
+    ///returns option first element and tail
+    let inline tryUncons (q : PhysicistQueue<'a>) = q.TryUncons

--- a/src/FSharpx.Core/FSharpx.Core.fsproj
+++ b/src/FSharpx.Core/FSharpx.Core.fsproj
@@ -70,6 +70,9 @@
     <Compile Include="DataStructures\BinaryTreeZipper.fs" />
     <Compile Include="DataStructures\ListZipper.fs" />
     <Compile Include="DataStructures\RoseTree.fs" />
+	<Compile Include="DataStructures\BankersQueue.fs" />
+	<Compile Include="DataStructures\BatchedQueue.fs" />
+	<Compile Include="DataStructures\PhysicistQueue.fs" />
     <Compile Include="Lens.fs" />
     <Compile Include="CSharpCompat.fs" />
     <Compile Include="Regex.fs" />

--- a/tests/FSharpx.DataStructures.Tests/FSharpx.DataStructures.Tests.fsproj
+++ b/tests/FSharpx.DataStructures.Tests/FSharpx.DataStructures.Tests.fsproj
@@ -62,6 +62,7 @@
     <Compile Include="RealTimeDequeTest.fs" />
     <Compile Include="LeftistHeapTest.fs" />
     <Compile Include="RoseTreeTest.fs" />
+    <Compile Include="IQueueTest.fs" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/FSharpx.DataStructures.Tests/FsCheckProperties.fs
+++ b/tests/FSharpx.DataStructures.Tests/FsCheckProperties.fs
@@ -15,6 +15,13 @@ let checkEquality<'a when 'a : equality> name =
         fun (x: 'a) (y: 'a) (z: 'a) ->
             if x = y && y = z then x = z else true
 
+let classifyCollect xs (count : int) (y : bool) =
+    y |> Prop.collect count
+    |> Prop.classify (xs.GetType().FullName.Contains("System.Int32")) "int"  
+    |> Prop.classify (xs.GetType().FullName.Contains("System.String")) "string"
+    |> Prop.classify (xs.GetType().FullName.Contains("System.Boolean")) "bool"
+    |> Prop.classify (xs.GetType().FullName.Contains("System.Object")) "object"
+
 module Gen =
     let rec infiniteSeq() =
         gen {
@@ -28,3 +35,19 @@ module Gen =
 
     let finiteLazyList() =
         Gen.map LazyList.ofList Arb.generate
+
+(*
+Recommend a range of size 1 - 12 for lists used to build test data structures:
+
+Several data structures, especially those where the internal data representation is either binary or skew binary, have "distinct failure modes
+across the low range of sizes". What I mean by this is "it is possible to have bugs specific to certain small sizes in these data structures". So it is 
+important that every structure size up to a certain value (let us say "8" for arguments sake) needs to be tested every time. By default FsCheck generates 
+100 (pseudo-random) lists. The larger the size range you allow for generation, the higher the chance these crucial small sizes will be skipped.
+*)
+    let listBool n  = Gen.listOfLength n Arb.generate<bool>
+
+    let listInt n  = Gen.listOfLength n Arb.generate<int>
+
+    let listObj n  = Gen.listOfLength n Arb.generate<obj>
+
+    let listString n  = Gen.listOfLength n Arb.generate<string>

--- a/tests/FSharpx.DataStructures.Tests/IQueueTest.fs
+++ b/tests/FSharpx.DataStructures.Tests/IQueueTest.fs
@@ -1,0 +1,387 @@
+﻿module FSharpx.DataStructures.Tests.IQueueTest
+
+open FSharpx
+open FSharpx.DataStructures
+open FSharpx.DataStructures.Interfaces
+open FSharpx.Tests.Properties
+open NUnit.Framework
+open FsCheck
+open FsCheck.NUnit
+open FsUnit
+
+let snocThruList l q  =
+    let rec loop (q' : 'a IQueue) (l' : 'a list) = 
+        match l' with
+        | hd :: [] -> q'.Snoc hd
+        | hd :: tl -> loop (q'.Snoc hd) tl
+        | [] -> q'
+        
+    loop q l
+
+let length1thru12 = Gen.choose (1, 12)
+let length2thru12 = Gen.choose (2, 12)
+(*
+non- IQueue generators from random ofList
+*)
+let batchedQueueOfListGen =
+        gen { let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (BatchedQueue.ofList x), x) }
+
+let physicistQueueOfListqGen =
+        gen { let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (PhysicistQueue.ofList x), x) }
+(*
+IQueue generators from random ofSeq and snoc elements from random list 
+*)
+let bankersQueueIntGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x = Gen.listInt n
+              let! y = Gen.listInt n2  
+              return ( (BankersQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let bankersQueueIntOfSeqGen =
+        gen { let! n = length2thru12
+              let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (BankersQueue.ofSeq x) :> IQueue<int>, x) }
+
+let bankersQueueIntSnocGen =
+        gen { let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (BankersQueue.empty() |> snocThruList x), x) }
+
+let batchedQueueIntGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listInt n
+              let! y =  Gen.listInt n2
+              return ( (BatchedQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let batchedQueueIntOfSeqGen =
+        gen { let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (BatchedQueue.ofSeq x) :> IQueue<int>, x) }
+
+let batchedQueueIntSnocGen =
+        gen { let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (BatchedQueue.empty() |> snocThruList x), x) }
+
+let physicistQueueIntGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x = Gen.listInt n
+              let! y = Gen.listInt n2
+              return ( (PhysicistQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let physicistQueueIntOfSeqGen =
+        gen { let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (PhysicistQueue.ofSeq x) :> IQueue<int>, x) }
+
+let physicistQueueIntSnocGen =
+        gen { let! n = length2thru12
+              let! x = Gen.listInt n
+              return ( (PhysicistQueue.empty() |> snocThruList x), x) }
+
+let bankersQueueObjGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listObj n
+              let! y =  Gen.listObj n2  
+              return ( (BankersQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let batchedQueueObjGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listObj n
+              let! y =  Gen.listObj n2
+              return ( (BatchedQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let physicistQueueObjGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listObj n
+              let! y =  Gen.listObj n2
+              return ( (PhysicistQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let bankersQueueStringGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listString n
+              let! y =  Gen.listString n2  
+              return ( (BankersQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let batchedQueueStringGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listString n
+              let! y =  Gen.listString n2  
+              return ( (BatchedQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let physicistQueueStringGen =
+        gen { let! n = length1thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listString n
+              let! y =  Gen.listString n2  
+              return ( (PhysicistQueue.ofSeq x |> snocThruList y), (x @ y) ) }
+
+let emptyIQueues =
+    let v = Array.create 3 (BankersQueue.empty() :> IQueue<obj>)
+    v.[1] <- (BatchedQueue.empty() :> IQueue<obj>)
+    v.[2] <- (PhysicistQueue.empty() :> IQueue<obj>)
+    v
+
+// NUnit TestCaseSource does not understand array of tuples at runtime
+let intGens start =
+    let v = Array.create 9 (box (bankersQueueIntGen, "BankersQueue"))
+    v.[1] <- box ((bankersQueueIntOfSeqGen |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "BankersQueue OfSeq")
+    v.[2] <- box ((bankersQueueIntSnocGen |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "BankersQueue Snoc")
+    v.[3] <- box (batchedQueueIntGen, "BatchedQueue")
+    v.[4] <- box ((batchedQueueIntOfSeqGen |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "BatchedQueue OfSeq")
+    v.[5] <- box ((batchedQueueIntSnocGen |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "BatchedQueue Snoc")
+    v.[6] <- box (physicistQueueIntGen, "PhysicistQueue")
+    v.[7] <- box ((physicistQueueIntOfSeqGen |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "PhysicistQueue OfSeq")
+    v.[8] <- box ((physicistQueueIntSnocGen |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "PhysicistQueue Snoc")
+    v
+
+let objGens =
+    let v = Array.create 3 (box (bankersQueueObjGen, "BankersQueue"))
+    v.[1] <- box (batchedQueueObjGen, "BatchedQueue")
+    v.[2] <- box (physicistQueueObjGen, "PhysicistQueue")
+    v
+
+let stringGens =
+    let v = Array.create 3 (box (bankersQueueStringGen, "BankersQueue"))
+    v.[1] <- box (batchedQueueStringGen, "BatchedQueue")
+    v.[2] <- box (physicistQueueStringGen, "PhysicistQueue")
+    v
+
+let intGensStart1 =
+    intGens 1  //this will accept all
+
+let intGensStart2 =
+    intGens 2 // this will accept 11 out of 12
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("emptyIQueues")>]
+let ``allow to dequeue``(eIQ : IQueue<obj>) =
+    ((eIQ.Snoc 1).Tail).IsEmpty |> should equal true
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("emptyIQueues")>]
+let ``allow to enqueue``(eIQ : IQueue<obj>) =
+    ((eIQ.Snoc 1).Snoc 2).IsEmpty |> should equal false
+
+[<Test>]
+[<Category("nonIQueue")>]
+[<Property("Category", "nonIQueue")>]
+let ``cons pattern discriminator - BankersQueue``() =
+    let q = BankersQueue.ofSeq  ["f";"e";"d";"c";"b";"a"]
+    
+    let h1, t1 = 
+        match q with
+        | BankersQueue.Cons(h, t) -> h, t
+        | _ ->  "x", q
+
+    ((h1 = "f") && (t1.Length = 5)) |> should equal true
+
+[<Test>]
+[<Category("nonIQueue")>]
+[<Property("Category", "nonIQueue")>]
+let ``cons pattern discriminator - BatchedQueue``() =
+    let q = BatchedQueue.ofSeq  ["f";"e";"d";"c";"b";"a"]
+    
+    let h1, t1 = 
+        match q with
+        | BatchedQueue.Cons(h, t) -> h, t
+        | _ ->  "x", q
+
+    ((h1 = "f") && (t1.Length = 5)) |> should equal true
+
+[<Test>]
+[<Category("nonIQueue")>]
+[<Property("Category", "nonIQueue")>]
+let ``cons pattern discriminator - PhysicistQueue``() =
+    let q = PhysicistQueue.ofSeq  ["f";"e";"d";"c";"b";"a"]
+    
+    let h1, t1 = 
+        match q with
+        | PhysicistQueue.Cons(h, t) -> h, t
+        | _ ->  "x", q
+
+    ((h1 = "f") && (t1.Length = 5)) |> should equal true
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("emptyIQueues")>]
+let ``empty queue should be empty``(eIQ : IQueue<obj>) =
+    eIQ.IsEmpty |> should equal true
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("emptyIQueues")>]
+let ``fail if there is no head in the queue``(eIQ : IQueue<obj>) =
+    let ok = ref false
+    try
+        eIQ.Head |> ignore
+    with x when x = Exceptions.Empty -> ok := true
+    !ok |> should equal true
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("emptyIQueues")>]
+let ``fail if there is no tail in the queue``(eIQ : IQueue<obj>) =
+    let ok = ref false
+    try
+        eIQ.Tail |> ignore
+    with x when x = Exceptions.Empty -> ok := true
+    !ok |> should equal true
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("intGensStart1")>]
+let ``int queue builds and serializes``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q |> Seq.toList = l |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("objGens")>]
+let ``obj queue builds and serializes``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<obj>, l) -> q |> Seq.toList = l |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("stringGens")>]
+let ``string queue builds and serializes``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<string>, l) -> q |> Seq.toList = l |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("nonIQueue")>]
+[<Property("Category", "nonIQueue")>]
+let ``reverse . reverse = id``() =
+
+    fsCheck "BankersQueue" (Prop.forAll (Arb.fromGen bankersQueueObjGen) 
+        (fun (q, l) -> q :?> BankersQueue<obj> |> BankersQueue.rev |> BankersQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q q.Length))
+    fsCheck "BatchedQueue" (Prop.forAll (Arb.fromGen batchedQueueObjGen) 
+        (fun (q, l) -> q :?> BatchedQueue<obj> |> BatchedQueue.rev |> BatchedQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q q.Length))
+    fsCheck "PhysicistQueue" (Prop.forAll (Arb.fromGen physicistQueueIntGen) 
+        (fun (q, l) -> q :?> PhysicistQueue<int> |> PhysicistQueue.rev |> PhysicistQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("nonIQueue")>]
+[<Property("Category", "nonIQueue")>]
+let ``ofList build and serialize``() =
+
+    fsCheck "BatchedQueue" (Prop.forAll (Arb.fromGen batchedQueueOfListGen) 
+        (fun ((q : BatchedQueue<int>), (l : int list)) -> q |> Seq.toList = l |> classifyCollect q q.Length))
+    fsCheck "PhysicistQueue" (Prop.forAll (Arb.fromGen physicistQueueOfListqGen) 
+        (fun ((q : PhysicistQueue<int>), (l : int list)) -> q |>  Seq.toList = l |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("nonIQueue")>]
+[<Property("Category", "nonIQueue")>]
+let ``fold matches build list rev``() =
+
+    fsCheck "BatchedQueue" (Prop.forAll (Arb.fromGen batchedQueueIntGen) 
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+              
+    fsCheck "BatchedQueue OfSeq" (Prop.forAll (Arb.fromGen batchedQueueIntOfSeqGen) 
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+
+    fsCheck "BatchedQueue Snoc" (Prop.forAll (Arb.fromGen batchedQueueIntSnocGen) 
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+
+    fsCheck "PhysicistQueue" (Prop.forAll (Arb.fromGen physicistQueueIntGen) 
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+              
+    fsCheck "PhysicistQueue OfSeq" (Prop.forAll (Arb.fromGen (physicistQueueIntOfSeqGen)) 
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+
+    fsCheck "PhysicistQueue Snoc" (Prop.forAll (Arb.fromGen (physicistQueueIntSnocGen)) 
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("nonIQueue")>]
+[<Property("Category", "nonIQueue")>]
+let ``foldback matches build list``() =
+
+    fsCheck "BatchedQueue" (Prop.forAll (Arb.fromGen batchedQueueIntGen) 
+        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q q.Length))
+              
+    fsCheck "BatchedQueue OfSeq" (Prop.forAll (Arb.fromGen batchedQueueIntOfSeqGen) 
+        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q q.Length))
+
+    fsCheck "BatchedQueue Snoc" (Prop.forAll (Arb.fromGen batchedQueueIntSnocGen) 
+        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q q.Length))
+
+    fsCheck "PhysicistQueue" (Prop.forAll (Arb.fromGen physicistQueueIntGen) 
+        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q q.Length))
+              
+    fsCheck "PhysicistQueue OfSeq" (Prop.forAll (Arb.fromGen physicistQueueIntOfSeqGen) 
+        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q q.Length))
+
+    fsCheck "PhysicistQueue Snoc" (Prop.forAll (Arb.fromGen physicistQueueIntSnocGen) 
+        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("emptyIQueues")>]
+let ``give None if there is no head in the queue``(eIQ : IQueue<obj>) =
+    eIQ.TryGetHead |> should equal None
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("emptyIQueues")>]
+let ``give None if there is no tail in the queue``(eIQ  : IQueue<obj>) =
+    eIQ.TryGetTail |> should equal None
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("intGensStart1")>]
+let ``get the head from a queue``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q.Head = (List.nth l 0) |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("intGensStart1")>]
+let ``get the head from a queue safely``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q.TryGetHead.Value = (List.nth l 0) |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("intGensStart2")>]
+let ``get the tail from the queue``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((q : IQueue<int>), l) -> q.Tail.Head = (List.nth l 1) |> classifyCollect q q.Length))
+
+[<Test>]
+[<Category("IQueue")>]
+[<Property("Category", "IQueue")>]
+[<TestCaseSource("intGensStart2")>]
+let ``get the tail from a queue safely``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q : IQueue<int>, l) -> q.TryGetTail.Value.Head = (List.nth l 1) |> classifyCollect q q.Length))


### PR DESCRIPTION
1) BankersQueue, BatchedQueue, PhysicistQueue
2) IQueueTest.fs tests all queues with IQueue interface

downcasts in IQueueTest to avoid more code that would not make it more
readable or more useable:
1) Arb.convert only converts types, not tuples, from concrete to
interface...so more overhead to get this working
2) Would have to implement snocThruList for every queue type
