### PR TITLE
LeftistHeap enumerable performance improvement

### DIFF
--- a/tests/FSharpx.DataStructures.Tests/LeftistHeapTest.fs
+++ b/tests/FSharpx.DataStructures.Tests/LeftistHeapTest.fs
@@ -1,161 +1,111 @@
 ﻿module FSharpx.DataStructures.Tests.LeftistHeapTest
 
-open System
+open FSharpx
 open FSharpx.DataStructures
 open FSharpx.DataStructures.LeftistHeap
+open FSharpx.Tests.Properties
 open NUnit.Framework
+open FsCheck
+open FsCheck.NUnit
 open FsUnit
 
+//only going up to 5 elements is probably sufficient to test all edge cases
 
-//only going up to len5 is probably sufficient to test all edge cases
-//but better too many unit tests than too few
+(*
+Could not get IHeap<'c, 'a when 'c :> IHeap<'c, 'a> and 'a : comparison> interface working smoothly between shared code,
+NUnit TestCaseSource(), FsCheck, and trying to pass around the tuple of heap generator and list. So need individual test
+file for each heap type, unlike IQueue.
 
-[<Test>]
-let ``empty list should be empty``() =
-    empty true |> isEmpty |> should equal true
+Even restricting only to this type, never got generic element type 'a to work. Need separate tests for int and string.
+*)
 
-[<Test>]
-let ``insert works``() =
-    empty false |> insert 1 |> insert 2 |> isEmpty |> should equal false
+let insertThruList l h  =
+    let rec loop (h' : LeftistHeap<'a>) (l' : 'a list) = 
+        match l' with
+        | hd :: [] -> h'.Insert hd
+        | hd :: tl -> loop (h'.Insert hd) tl
+        | [] -> h' 
+        
+    loop h l
 
-[<Test>]
-let ``uncons 1 element``() =
-    let x, _ = empty true |> insert 1 |>  uncons
-    x |> should equal 1
+let length1thru12 = Gen.choose (1, 12)
+let length2thru12 = Gen.choose (2, 12)
+let length1001thru2000 = Gen.choose (1001, 2000)
 
-[<Test>]
-let ``uncons 2 elements``() =
-    let x, _ = empty true |> insert 1 |> insert 2 |> uncons 
-    x |> should equal 2
+(* LeftistHeap Gens *)
+let maxLeftistHeapIntGen =
+        gen { let! n = length2thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listInt n
+              let! y =  Gen.listInt n2
+              return ( (LeftistHeap.ofSeq true x |> insertThruList y), ((x @ y) |> List.sort |> List.rev) ) }
 
-[<Test>]
-let ``uncons 3 elements``() =
-    let x, _ = empty false |> insert 1 |> insert 2 |> insert 3 |> uncons 
-    x |> should equal 1
+let maxLeftistHeapIntOfSeqGen =
+        gen { let! n = length1thru12
+              let! x =  Gen.listInt n
+              return ( (LeftistHeap.ofSeq true x), (x |> List.sort |> List.rev) ) }
 
-[<Test>]
-let ``tryUncons 1 element``() =
-    let x = empty false |> insert 1 |> tryUncons
-    fst(x.Value)  |> should equal 1
+let maxLeftistHeapIntInsertGen =
+        gen { let! n = length1thru12
+              let! x =  Gen.listInt n
+              return ( (LeftistHeap.empty true |> insertThruList x), (x |> List.sort |> List.rev) ) }
 
-[<Test>]
-let ``tryUncons 2 elements``() =
-    let x = empty false |> insert 1 |> insert 2 |> tryUncons
-    fst(x.Value) |> should equal 1
+let maxLeftistHeapStringGen =
+        gen { let! n = length1thru12
+              let! n2 = length2thru12
+              let! x =  Gen.listString n
+              let! y =  Gen.listString n2
+              return ( (LeftistHeap.ofSeq true x |> insertThruList y), ((x @ y) |> List.sort |> List.rev) ) }
 
-[<Test>]
-let ``tryUncons 3 elements``() =
-    let x = empty true |> insert 1 |> insert 2 |> insert 3 |> tryUncons 
-    fst(x.Value) |> should equal 3
+let minLeftistHeapIntGen =
+        gen { let! n = length2thru12
+              let! n2 = length1thru12
+              let! x =  Gen.listInt n
+              let! y =  Gen.listInt n2
+              return ( (LeftistHeap.ofSeq false x |> insertThruList y), ((x @ y) |> List.sort) ) }
 
-[<Test>]
-let ``tryUncons empty``() =
-    empty false |> tryUncons |> should equal None
-    
-[<Test>]
-let ``head should return``() =
-    let x = empty true |> insert 1 |> insert 2 |> head 
-    x |> should equal 2
+let minLeftistHeapIntOfSeqGen =
+        gen { let! n = length1thru12
+              let! x =  Gen.listInt n
+              return ( (LeftistHeap.ofSeq false x), (x |> List.sort |> List.rev) ) }
 
-[<Test>]
-let ``tryGetHead should return``() =
-    let x = empty false |> insert 1 |> insert 2 |> tryGetHead 
-    x.Value |> should equal 1
+let minLeftistHeapIntInsertGen =
+        gen { let! n = length1thru12
+              let! x =  Gen.listInt n
+              return ( (LeftistHeap.empty false |> insertThruList x), (x |> List.sort |> List.rev) ) }
 
-[<Test>]
-let ``tryGetHead on empty should return None``() =
-    empty true |> tryGetHead |> should equal None
+let minLeftistHeapStringGen =
+        gen { let! n = length1thru12
+              let! n2 = length2thru12
+              let! x =  Gen.listString n
+              let! y =  Gen.listString n2
+              return ( (LeftistHeap.ofSeq false x |> insertThruList y), ((x @ y) |> List.sort) ) }
 
-[<Test>]
-let ``tryGetTail on empty should return None``() =
-    empty false |> tryGetTail |> should equal None
+let longLeftistHeapIntOfSeqGen =
+        gen { let! n = length1001thru2000
+              let! x = Gen.listInt n
+              return ( (LeftistHeap.ofSeq true x), (x |> List.sort |> List.rev) ) }
 
-[<Test>]
-let ``tryGetTail on len 1 should return Some empty``() =
-    let x = (empty true |> insert 1 |> tryGetTail).Value
-    x |> isEmpty |> should equal true
+// NUnit TestCaseSource does not understand array of tuples at runtime
+let intGens start =
+    let v = Array.create 6 (box (maxLeftistHeapIntGen, "max LeftistHeap int"))
+    v.[1] <- box ((maxLeftistHeapIntOfSeqGen  |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "max LeftistHeap OfSeq")
+    v.[2] <- box ((maxLeftistHeapIntInsertGen  |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "max LeftistHeap from Insert")
+    v.[3] <- box (maxLeftistHeapIntGen , "max LeftistHeap int")
+    v.[4] <- box ((maxLeftistHeapIntOfSeqGen  |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "max LeftistHeap OfSeq")
+    v.[5] <- box ((maxLeftistHeapIntInsertGen  |> Gen.suchThat (fun (q, l) -> l.Length >= start)), "max LeftistHeap from Insert")
+    v
 
-[<Test>]
-let ``tail on len 2 should return``() =
-    empty true |> insert 1 |>  insert 2 |> tail |> head |> should equal 1
+let stringGens =
+    let v = Array.create 2 (box (maxLeftistHeapStringGen, "max LeftistHeap string"))
+    v.[1] <- box (maxLeftistHeapStringGen, "max LeftistHeap string")
+    v
 
-[<Test>]
-let ``tryGetTail on len 2 should return``() =
-    let a = empty false |> insert 1 |>  insert 2 |> tryGetTail 
-    ((head a.Value) = 2) |> should equal true
+let intGensStart1 =
+    intGens 1  //this will accept all
 
-[<Test>]
-let ``length of empty is 0``() =
-    empty false |> length |> should equal 0
-
-[<Test>]
-let ``length of 1 - 10 good``() =
-
-    let len1 = empty true |> insert "a"
-    let len2 = empty true |> insert "a" |> insert "b"
-    let len3 = empty true |> insert "a" |> insert "b" |> insert "c"
-    let len4 = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d"
-    let len5 = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e"
-    let len6 = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e" |> insert "f"
-    let len7 = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e" |> insert "f" |> insert "g"
-    let len8 = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e" |> insert "f" |> insert "g" |> insert "h"
-    let len9 = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e" |> insert "f" |> insert "g" |> insert "h" |> insert "i"
-    let lena = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e" |> insert "f" |> insert "g" |> insert "h" |> insert "i" |> insert "j"
-
-    (((length len1) = 1) && ((length len2) = 2) && ((length len3) = 3) && ((length len4) = 4) 
-    && ((length len5) = 5) && ((length len6) = 6) && ((length len7) = 7) && ((length len8) = 8) 
-    && ((length len9) = 9) && ((length lena) = 10)) |> should equal true
-
-[<Test>]
-let ``ofSeq minimalist``() =
-    let x = ofSeq false ["a";"b";"c";"d";"e";"f";"g";"h";"i";"j"]
-
-    let a, t1 = uncons x
-    let b, t2 = uncons t1
-    let c, t3 = uncons t2
-    let d, t4 = uncons t3
-    let e, t5 = uncons t4
-    let f, t6 = uncons t5
-    let g, t7 = uncons t6
-    let h, t8 = uncons t7
-    let i, t9 = uncons t8
-    let j, t10 = uncons t9
-    ((a = "a") && (b = "b") && (c = "c") && (d = "d") && (e = "e") && (f = "f") && (g = "g") && (h = "h") 
-    && (i = "i") && (j = "j") && (t10 |> isEmpty)) |> should equal true
-
-[<Test>]
-let ``ofSeq minimalist odd number``() =
-    let x = ofSeq false ["a";"b";"c";"d";"e";"f";"g";"h";"i"]
-
-    let a, t1 = uncons x
-    let b, t2 = uncons t1
-    let c, t3 = uncons t2
-    let d, t4 = uncons t3
-    let e, t5 = uncons t4
-    let f, t6 = uncons t5
-    let g, t7 = uncons t6
-    let h, t8 = uncons t7
-    let i, t9 = uncons t8
-    ((a = "a") && (b = "b") && (c = "c") && (d = "d") && (e = "e") && (f = "f") && (g = "g") && (h = "h") 
-    && (i = "i") && (t9 |> isEmpty)) |> should equal true
-
-[<Test>]
-let ``ofSeq maximalist``() =
-    let x = ofSeq true ["a";"b";"c";"d";"e";"f";"g";"h";"i";"j"]
-
-    let j, t1 = uncons x
-    let i, t2 = uncons t1
-    let h, t3 = uncons t2
-    let g, t4 = uncons t3
-    let f, t5 = uncons t4
-    let e, t6 = uncons t5
-    let d, t7 = uncons t6
-    ((d = "d") && (e = "e") && (f = "f") && (g = "g") && (h = "h") && (i = "i") && (j = "j")) |> should equal true
-
-[<Test>]
-let ``IHeap insert works``() =
-    let lena = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e" |> insert "f" |> insert "g" |> insert "h" |> insert "i" |> insert "j"
-    ((lena :> IHeap<_, string>).Insert "zz").Head |> should equal "zz"
+let intGensStart2 =
+    intGens 2 // this will accept 11 out of 12
 
 [<Test>]
 let ``cons pattern discriminator``() =
@@ -183,6 +133,56 @@ let ``cons pattern discriminator 2``() =
     ((h1 = "d") && ((length t2) = 4)) |> should equal true
 
 [<Test>]
+let ``empty list should be empty``() = 
+    (LeftistHeap.empty true).IsEmpty |> should equal true
+
+[<Test>]
+[<TestCaseSource("intGensStart2")>]
+let ``head should return``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : LeftistHeap<int>), (l : int list)) ->    
+                                                                            (h.Head = l.Head)     
+                                                                            |> classifyCollect h h.Length))
+
+[<Test>]
+let ``IHeap insert works``() =
+    let h = empty true |> insert "a" |> insert "b" |> insert "c" |> insert "d" |> insert "e" |> insert "f" |> insert "g" |> insert "h" |> insert "i" |> insert "j"
+    ((h :> IHeap<_, string>).Insert "zz").Head |> should equal "zz"
+
+[<Test>]
+let ``insert works``() =
+    (((LeftistHeap.empty true).Insert 1).Insert 2).IsEmpty |> should equal false
+
+[<Test>]
+let ``seq enumerate matches build list``() =
+
+    fsCheck "maxLeftistHeap" (Prop.forAll (Arb.fromGen maxLeftistHeapIntGen) 
+        (fun (h, l) -> h |> List.ofSeq = l |> classifyCollect h h.Length))
+
+    fsCheck "minLeftistHeap" (Prop.forAll (Arb.fromGen minLeftistHeapIntGen) 
+        (fun (h, l) -> h |> List.ofSeq = l |> classifyCollect h h.Length))
+
+[<Test>]
+let ``length of empty is 0``() =
+    (LeftistHeap.empty true).Length |> should equal 0
+
+[<Test>]
+[<TestCaseSource("intGensStart1")>]
+let ``seq enumerate matches build list int``(x : obj) =
+    let genAndName = unbox x
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (h : LeftistHeap<int>, l) -> h |> Seq.toList = l |> classifyCollect h h.Length))
+
+[<Test>]
+[<TestCaseSource("stringGens")>]
+let ``seq enumerate matches build list string``(x : obj) =
+    let genAndName = unbox x
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (h : LeftistHeap<string>, l) -> h |> Seq.toList = l |> classifyCollect h h.Length))
+
+[<Test>]
+let ``seq enumerate matches long build list``() =
+    fsCheck "long build list" (Prop.forAll (Arb.fromGen longLeftistHeapIntOfSeqGen) (fun (h : LeftistHeap<int>, l) -> h |> Seq.toList = l |> classifyCollect h h.Length))
+
+[<Test>]
 let ``structure pattern match and merge``() =
     let h = ofSeq true ["f";"e";"d";"c";"b";"a"]
 
@@ -198,8 +198,63 @@ let ``structure pattern match and merge``() =
     ((x = "f") && (x2 = "e") && ((length t3) = 4)) |> should equal true
 
 [<Test>]
+[<TestCaseSource("intGensStart2")>]
+let ``tail should return``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : LeftistHeap<int>), (l : int list)) ->    
+                                                                            let tl = h.Tail
+                                                                            let tlHead =
+                                                                                if (tl.Length > 0) then (tl.Head = l.Item(1))
+                                                                                else true
+                                                                            (tlHead && (tl.Length = (l.Length - 1)))     
+                                                                            |> classifyCollect h h.Length))
+
+[<Test>]
+let ``tryGetHead on empty should return None``() =
+    (LeftistHeap.empty true).TryGetHead |> should equal None
+
+[<Test>]
+[<TestCaseSource("intGensStart2")>]
+let ``tryGetHead should return``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : LeftistHeap<int>), (l : int list)) ->    
+                                                                            (h.TryGetHead.Value = l.Head)     
+                                                                            |> classifyCollect h h.Length))
+
+[<Test>]
+let ``tryGetTail on empty should return None``() =
+    (LeftistHeap.empty true).TryGetTail |> should equal None
+
+[<Test>]
+let ``tryGetTail on len 1 should return Some empty``() =
+    let h = LeftistHeap.empty true |> insert 1 |> tryGetTail
+    h.Value |> isEmpty |> should equal true
+
+[<Test>]
 let ``tryMerge max and mis should be None``() =
     let h1 = ofSeq true ["f";"e";"d";"c";"b";"a"]
     let h2 = ofSeq false ["t";"u";"v";"w";"x";"y";"z"]
 
     tryMerge h1 h2 |> should equal None
+
+[<Test>]
+[<TestCaseSource("intGensStart2")>]
+let ``tryUncons 1 element``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : LeftistHeap<int>), (l : int list)) ->    
+                                                                            let x, tl = h.TryUncons.Value
+                                                                            ((x = l.Head) && (tl.Length = (l.Length - 1)))     
+                                                                            |> classifyCollect h h.Length))
+
+[<Test>]
+let ``tryUncons empty``() =
+    (LeftistHeap.empty true).TryUncons |> should equal None
+
+[<Test>]
+[<TestCaseSource("intGensStart2")>]
+let ``uncons 1 element``(x : obj) =
+    let genAndName = unbox x 
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : LeftistHeap<int>), (l : int list)) ->    
+                                                                            let x, tl = h.Uncons
+                                                                            ((x = l.Head) && (tl.Length = (l.Length - 1)))     
+                                                                            |> classifyCollect h h.Length))


### PR DESCRIPTION
1) LeftistHeap enumerable performance improved when number of elements >
1,000
2) complete rewrite of LeftistHeapTest.fs
