### PR TITLE
correct non-O(1) properties to methods

### DIFF
--- a/src/FSharpx.Core/DataStructures/BankersQueue.fs
+++ b/src/FSharpx.Core/DataStructures/BankersQueue.fs
@@ -84,7 +84,7 @@ type BankersQueue<'a> (frontLength : int, front : LazyList<'a>, backLength : int
     with
     interface IQueue<'a> with
 
-        member this.Count = this.Length
+        member this.Count() = this.Length
 
         member this.Head = this.Head
 
@@ -92,7 +92,7 @@ type BankersQueue<'a> (frontLength : int, front : LazyList<'a>, backLength : int
 
         member this.IsEmpty = this.IsEmpty
 
-        member this.Length = this.Length
+        member this.Length() = this.Length
 
         member this.Snoc x = this.Snoc x :> _
 

--- a/src/FSharpx.Core/DataStructures/BatchedQueue.fs
+++ b/src/FSharpx.Core/DataStructures/BatchedQueue.fs
@@ -94,7 +94,7 @@ type BatchedQueue<'a> (front : list<'a>, rBack : list<'a>) =
     with
     interface IQueue<'a> with
 
-        member this.Count = this.Length
+        member this.Count() = this.Length
 
         member this.Head = this.Head
 
@@ -102,7 +102,7 @@ type BatchedQueue<'a> (front : list<'a>, rBack : list<'a>) =
 
         member this.IsEmpty = this.IsEmpty
 
-        member this.Length = this.Length
+        member this.Length() = this.Length
 
         member this.Snoc x = this.Snoc x :> _
 

--- a/src/FSharpx.Core/DataStructures/BinomialHeap.fs
+++ b/src/FSharpx.Core/DataStructures/BinomialHeap.fs
@@ -12,11 +12,9 @@ type BinomialTree<'a> = Node of (int * 'a * list<BinomialTree<'a>>)
 
 type BinomialHeap<'a when 'a : comparison> (isMaximalist : bool, heap : list<BinomialTree<'a>>) =
 
-
-
     member private this.heap = heap
 
-    ///returns true if the heap has max element at head
+    ///returns true if the heap has max element at head, O(1)
     member this.IsMaximalist = isMaximalist
 
     ///returns the count of elememts, O(log n)
@@ -119,45 +117,45 @@ type BinomialHeap<'a when 'a : comparison> (isMaximalist : bool, heap : list<Bin
 
     static member private inOrder (h : list<BinomialTree<'a>>) = (BinomialHeap.foldHeap (fun x l r acc -> l (x :: (r acc))) (fun acc -> acc) h) [] 
 
-    ///returns the min or max element
-    member this.Head = BinomialHeap.head this.IsMaximalist this.heap
+    ///returns the min or max element, O(log n)
+    member this.Head() = BinomialHeap.head this.IsMaximalist this.heap
 
-    ///returns option first min or max element
-    member this.TryGetHead = 
+    ///returns option first min or max element, O(log n)
+    member this.TryGetHead() = 
         if this.heap.IsEmpty then None
         else Some(BinomialHeap.head this.IsMaximalist this.heap)
 
-    ///returns a new heap with the element inserted
+    ///returns a new heap with the element inserted, O(log n)
     member this.Insert x  = BinomialHeap<'a>(this.IsMaximalist, (BinomialHeap.insert this.IsMaximalist x this.heap))
 
-    ///returns true if the heap has no elements
+    ///returns true if the heap has no elements, O(1)
     member this.IsEmpty = BinomialHeap.isEmpty this
 
-    ///returns heap from merging two heaps, both must have same isMaximalist
+    ///returns heap from merging two heaps, both must have same isMaximalist, O(log n)
     member this.Merge (xs : BinomialHeap<'a>) : BinomialHeap<'a> = 
         if (this.IsMaximalist = xs.IsMaximalist) then
             BinomialHeap<'a>(this.IsMaximalist, (BinomialHeap.merge this.IsMaximalist this.heap xs.heap))
         else failwith "not same max or min"
 
-    ///returns heap option from merging two heaps
+    ///returns heap option from merging two heaps, O(log n)
     member this.TryMerge (xs : BinomialHeap<'a>) = 
         if (this.IsMaximalist <> xs.IsMaximalist) then None
         else Some(BinomialHeap<'a>(this.IsMaximalist, (BinomialHeap.merge this.IsMaximalist this.heap xs.heap)))
 
-    ///returns a new heap of the elements trailing the head
-    member this.Tail = 
+    ///returns a new heap of the elements trailing the head, O(log n)
+    member this.Tail() = 
         BinomialHeap<'a>(this.IsMaximalist, (BinomialHeap.tail this.IsMaximalist this.heap))
        
-    ///returns option heap of the elements trailing the head
-    member this.TryGetTail = 
+    ///returns option heap of the elements trailing the head, O(log n)
+    member this.TryGetTail() = 
         if this.heap.IsEmpty then None
         else Some(BinomialHeap<'a>(this.IsMaximalist, (BinomialHeap.tail this.IsMaximalist this.heap)))
 
-    ///returns the head element and tail
-    member this.Uncons = BinomialHeap.uncons this.IsMaximalist this.heap
+    ///returns the head element and tail, O(log n)
+    member this.Uncons() = BinomialHeap.uncons this.IsMaximalist this.heap
 
-    ///returns option head element and tail
-    member this.TryUncons = 
+    ///returns option head element and tail, O(log n)
+    member this.TryUncons() = 
         if this.heap.IsEmpty then None
         else Some(BinomialHeap.uncons this.IsMaximalist this.heap)
 
@@ -182,46 +180,46 @@ type BinomialHeap<'a when 'a : comparison> (isMaximalist : bool, heap : list<Bin
 
 module BinomialHeap = 
     //pattern discriminator
-    let (|Cons|Nil|) (h: BinomialHeap<'a>) = match h.TryUncons with Some(a,b) -> Cons(a,b) | None -> Nil
+    let (|Cons|Nil|) (h: BinomialHeap<'a>) = match h.TryUncons() with Some(a,b) -> Cons(a,b) | None -> Nil
   
-    ///returns a empty heap
+    ///returns a empty heap, O(1)
     let empty (maximalist: bool) = BinomialHeap.empty maximalist
 
-    ///returns the min or max element
-    let inline head (xs: BinomialHeap<'a>)  = xs.Head
+    ///returns the min or max element, O(log n)
+    let inline head (xs: BinomialHeap<'a>)  = xs.Head()
 
-    ///returns option first min or max element
-    let inline tryGetHead (xs: BinomialHeap<'a>)  = xs.TryGetHead
+    ///returns option first min or max element, O(log n)
+    let inline tryGetHead (xs: BinomialHeap<'a>)  = xs.TryGetHead()
 
-    ///returns a new heap with the element inserted
+    ///returns a new heap with the element inserted, O(log n)
     let inline insert x (xs: BinomialHeap<'a>) = xs.Insert x   
 
-    ///returns true if the heap has no elements
+    ///returns true if the heap has no elements, O(1)
     let inline isEmpty (xs: BinomialHeap<'a>) = xs.IsEmpty
 
-    ///returns true if the heap has max element at head
+    ///returns true if the heap has max element at head, O(1)
     let inline isMaximalist (xs: BinomialHeap<'a>) = xs.IsMaximalist
 
-    ///returns the count of elememts
+    ///returns the count of elememts, O(log n)
     let inline length (xs: BinomialHeap<'a>) = xs.Length() 
 
-    ///returns heap from merging two heaps, both must have same isMaximalist
+    ///returns heap from merging two heaps, both must have same isMaximalist, O(log n)
     let inline merge (xs: BinomialHeap<'a>) (ys: BinomialHeap<'a>) = xs.Merge ys
 
-    ///returns heap option from merging two heaps
+    ///returns heap option from merging two heaps, O(log n)
     let inline tryMerge (xs: BinomialHeap<'a>) (ys: BinomialHeap<'a>) = xs.TryMerge ys
 
-    ///returns heap from the sequence
+    ///returns heap from the sequence, O(log n)
     let ofSeq maximalist s = BinomialHeap.ofSeq maximalist s
 
-    ///returns a new heap of the elements trailing the head
-    let inline tail (xs: BinomialHeap<'a>) = xs.Tail
+    ///returns a new heap of the elements trailing the head, O(log n)
+    let inline tail (xs: BinomialHeap<'a>) = xs.Tail()
 
-    ///returns option heap of the elements trailing the head
-    let inline tryGetTail (xs: BinomialHeap<'a>) = xs.TryGetTail
+    ///returns option heap of the elements trailing the head, O(log n)
+    let inline tryGetTail (xs: BinomialHeap<'a>) = xs.TryGetTail()
 
-    ///returns the head element and tail
-    let inline uncons (xs: BinomialHeap<'a>) = xs.Uncons
+    ///returns the head element and tail, O(log n)
+    let inline uncons (xs: BinomialHeap<'a>) = xs.Uncons()
 
-    ///returns option head element and tail
-    let inline tryUncons (xs: BinomialHeap<'a>) = xs.TryUncons
+    ///returns option head element and tail, O(log n)
+    let inline tryUncons (xs: BinomialHeap<'a>) = xs.TryUncons()

--- a/src/FSharpx.Core/DataStructures/HoodMelvilleQueue.fs
+++ b/src/FSharpx.Core/DataStructures/HoodMelvilleQueue.fs
@@ -133,7 +133,7 @@ type HoodMelvilleQueue<'a> (frontLength : int, front : list<'a>, state : Rotatio
     with
     interface IQueue<'a> with
 
-        member this.Count = this.Length
+        member this.Count() = this.Length
 
         member this.Head = this.Head
 
@@ -141,7 +141,7 @@ type HoodMelvilleQueue<'a> (frontLength : int, front : list<'a>, state : Rotatio
 
         member this.IsEmpty = this.IsEmpty
 
-        member this.Length = this.Length
+        member this.Length() = this.Length
 
         member this.Snoc x = this.Snoc x :> _
 

--- a/src/FSharpx.Core/DataStructures/Interfaces.fs
+++ b/src/FSharpx.Core/DataStructures/Interfaces.fs
@@ -104,13 +104,13 @@ type IHeap<'a when 'a : comparison> =
     inherit System.Collections.Generic.IEnumerable<'a>
 
     ///returns the count of elememts
-    abstract member Count : int with get
+    abstract member Count : unit -> int
 
     ///returns the min or max element
-    abstract member Head : 'a with get
+    abstract member Head : unit -> 'a 
 
     ///returns option first min or max element
-    abstract member TryGetHead : 'a option with get
+    abstract member TryGetHead : unit -> 'a option
 
     ///returns true if the heap has no elements
     abstract member IsEmpty : bool with get
@@ -119,7 +119,7 @@ type IHeap<'a when 'a : comparison> =
     abstract member IsMaximalist : bool with get
 
     ///returns the count of elememts
-    abstract member Length : int with get
+    abstract member Length : unit -> int
 
 type IHeap<'c, 'a when 'c :> IHeap<'c, 'a> and 'a : comparison> =
     inherit IHeap<'a>
@@ -134,23 +134,23 @@ type IHeap<'c, 'a when 'c :> IHeap<'c, 'a> and 'a : comparison> =
     abstract member TryMerge : 'c -> 'c option
 
     ///returns a new heap of the elements trailing the head
-    abstract member Tail : 'c with get
+    abstract member Tail : unit -> 'c 
 
     ///returns option heap of the elements trailing the head
-    abstract member TryGetTail : 'c option with get
+    abstract member TryGetTail : unit -> 'c option 
 
     ///returns the head element and tail
-    abstract member Uncons : 'a * 'c with get
+    abstract member Uncons : unit -> ('a * 'c) 
 
     ///returns option head element and tail
-    abstract member TryUncons : ('a * 'c) option with get
+    abstract member TryUncons : unit -> ('a * 'c) option
 
 type IQueue<'a> =
     inherit System.Collections.IEnumerable
     inherit System.Collections.Generic.IEnumerable<'a>
  
     ///returns the count of elememts
-    abstract member Count :int with get
+    abstract member Count : unit -> int
 
     ///returns the first element
     abstract member Head :'a with get
@@ -162,7 +162,7 @@ type IQueue<'a> =
     abstract member IsEmpty :bool with get
 
     ///returns the count of elememts
-    abstract member Length :int with get
+    abstract member Length : unit -> int
 
     ///returns a new queue with the element added to the end
     abstract member Snoc : 'a -> IQueue<'a>

--- a/src/FSharpx.Core/DataStructures/LeftistHeap.fs
+++ b/src/FSharpx.Core/DataStructures/LeftistHeap.fs
@@ -108,56 +108,56 @@ type LeftistHeap<'a when 'a : comparison> =
             | None -> None
             | Some(x) -> Some(x, (LeftistHeap.tail h))
         
-    ///returns the min or max element
+    ///returns the min or max element, O(1)
     member this.Head = LeftistHeap.head this
 
-    ///returns option first min or max element
+    ///returns option first min or max element, O(1)
     member this.TryGetHead = LeftistHeap.tryGetHead this
 
-    ///returns a new heap with the element inserted
+    ///returns a new heap with the element inserted, O(log n)
     member this.Insert x  = LeftistHeap.insert x this
 
-    ///returns true if the heap has no elements
+    ///returns true if the heap has no elements, O(1)
     member this.IsEmpty = LeftistHeap.isEmpty this
 
-    ///returns true if the heap has max element at head
+    ///returns true if the heap has max element at head, O(1)
     member this.IsMaximalist : bool = 
         match this with
         | E(m) -> m 
         |  T(m, _, _, _, _, _) -> m
 
-    ///returns the count of elememts
+    ///returns the count of elememts, O(1)
     member this.Length : int = 
         match this with
         | E(_) -> 0
         | T(_, i, _, _, _, _) -> i
 
-    ///returns heap from merging two heaps, both must have same isMaximalist
+    ///returns heap from merging two heaps, both must have same isMaximalist, O(log n)
     member this.Merge xs = LeftistHeap.merge this xs
 
-    ///returns heap option from merging two heaps
+    ///returns heap option from merging two heaps, O(log n)
     member this.TryMerge xs = LeftistHeap.tryMerge this xs
 
-    ///returns a new heap of the elements trailing the head
+    ///returns a new heap of the elements trailing the head, O(log n)
     member this.Tail = LeftistHeap.tail this
        
-    ///returns option heap of the elements trailing the head
+    ///returns option heap of the elements trailing the head, O(log n)
     member this.TryGetTail = LeftistHeap.tryGetTail this
 
-    ///returns the head element and tail
-    member this.Uncons = 
+    ///returns the head element and tail, O(log n)
+    member this.Uncons() = 
         (LeftistHeap.head this), (LeftistHeap.tail this)
 
-    ///returns option head element and tail
-    member this.TryUncons = LeftistHeap.tryUncons this
+    ///returns option head element and tail, O(log n)
+    member this.TryUncons() = LeftistHeap.tryUncons this
 
     interface IHeap<LeftistHeap<'a>, 'a> with
         
-        member this.Count = this.Length
+        member this.Count() = this.Length
 
-        member this.Head = LeftistHeap.head this
+        member this.Head() = LeftistHeap.head this
 
-        member this.TryGetHead = LeftistHeap.tryGetHead this
+        member this.TryGetHead() = LeftistHeap.tryGetHead this
 
         member this.Insert (x : 'a) = LeftistHeap.insert x this
 
@@ -165,7 +165,7 @@ type LeftistHeap<'a when 'a : comparison> =
 
         member this.IsMaximalist = this.IsMaximalist 
 
-        member this.Length = this.Length 
+        member this.Length() = this.Length 
 
         member this.Merge (xs : LeftistHeap<'a>) = LeftistHeap.merge this xs
 
@@ -174,17 +174,17 @@ type LeftistHeap<'a when 'a : comparison> =
             | None -> None
             | Some(xs) -> Some(xs)
 
-        member this.Tail = LeftistHeap.tail this
+        member this.Tail() = LeftistHeap.tail this
 
-        member this.TryGetTail =
+        member this.TryGetTail() =
             match LeftistHeap.tryGetTail this with
             | None -> None
             | Some(xs) -> Some(xs)
 
-        member this.Uncons = 
+        member this.Uncons() = 
             (LeftistHeap.head this), (LeftistHeap.tail this) 
 
-        member this.TryUncons =
+        member this.TryUncons() =
             match LeftistHeap.tryUncons this with
             | None -> None
             | Some(x, xs) -> Some(x, xs)
@@ -208,46 +208,46 @@ type LeftistHeap<'a when 'a : comparison> =
 module LeftistHeap =   
     //pattern discriminator
 
-    let (|Cons|Nil|) (h: LeftistHeap<'a>) = match h.TryUncons with Some(a,b) -> Cons(a,b) | None -> Nil
+    let (|Cons|Nil|) (h: LeftistHeap<'a>) = match h.TryUncons() with Some(a,b) -> Cons(a,b) | None -> Nil
   
-    ///returns a empty heap
+    ///returns a empty heap, O(1)
     let inline empty (maximalist: bool) = E(maximalist)
 
-    ///returns the min or max element
+    ///returns the min or max element, O(1)
     let inline head (xs: LeftistHeap<'a>)  = xs.Head
 
-    ///returns option first min or max element
+    ///returns option first min or max element, O(1)
     let inline tryGetHead (xs: LeftistHeap<'a>)  = xs.TryGetHead
 
-    ///returns a new heap with the element inserted
+    ///returns a new heap with the element inserted, O(log n)
     let inline insert x (xs: LeftistHeap<'a>) = xs.Insert x   
 
-    ///returns true if the heap has no elements
+    ///returns true if the heap has no elements, O(1)
     let inline isEmpty (xs: LeftistHeap<'a>) = xs.IsEmpty
 
-    ///returns true if the heap has max element at head
+    ///returns true if the heap has max element at head, O(1)
     let inline isMaximalist (xs: LeftistHeap<'a>) = xs.IsMaximalist
 
-    ///returns the count of elememts
+    ///returns the count of elememts, O(1)
     let inline length (xs: LeftistHeap<'a>) = xs.Length 
 
-    ///returns heap from merging two heaps, both must have same isMaximalist
+    ///returns heap from merging two heaps, both must have same isMaximalist, O(log n)
     let inline merge (xs: LeftistHeap<'a>) (ys: LeftistHeap<'a>) = xs.Merge ys
 
-    ///returns heap option from merging two heaps
+    ///returns heap option from merging two heaps, O(log n)
     let inline tryMerge (xs: LeftistHeap<'a>) (ys: LeftistHeap<'a>) = xs.TryMerge ys
 
-    ///returns heap from the sequence
+    ///returns heap from the sequence, O(log n)
     let ofSeq maximalist s = LeftistHeap.ofSeq maximalist s
 
-    ///returns a new heap of the elements trailing the head
+    ///returns a new heap of the elements trailing the head, O(log n)
     let inline tail (xs: LeftistHeap<'a>) = xs.Tail
 
-    ///returns option heap of the elements trailing the head
+    ///returns option heap of the elements trailing the head, O(log n)
     let inline tryGetTail (xs: LeftistHeap<'a>) = xs.TryGetTail
 
-    ///returns the head element and tail
-    let inline uncons (xs: LeftistHeap<'a>) = xs.Uncons
+    ///returns the head element and tail, O(log n)
+    let inline uncons (xs: LeftistHeap<'a>) = xs.Uncons()
 
-    ///returns option head element and tail
-    let inline tryUncons (xs: LeftistHeap<'a>) = xs.TryUncons
+    ///returns option head element and tail, O(log n)
+    let inline tryUncons (xs: LeftistHeap<'a>) = xs.TryUncons()

--- a/src/FSharpx.Core/DataStructures/PhysicistQueue.fs
+++ b/src/FSharpx.Core/DataStructures/PhysicistQueue.fs
@@ -116,7 +116,7 @@ type PhysicistQueue<'a> (prefix : list<'a>, frontLength : int, front : Lazy<list
     with
     interface IQueue<'a> with
 
-        member this.Count = this.Length
+        member this.Count() = this.Length
 
         member this.Head = this.Head
 
@@ -124,7 +124,7 @@ type PhysicistQueue<'a> (prefix : list<'a>, frontLength : int, front : Lazy<list
 
         member this.IsEmpty = this.IsEmpty
 
-        member this.Length = this.Length
+        member this.Length() = this.Length
 
         member this.Snoc x = this.Snoc x :> _
 

--- a/tests/FSharpx.DataStructures.Tests/BinomialHeapTest.fs
+++ b/tests/FSharpx.DataStructures.Tests/BinomialHeapTest.fs
@@ -132,7 +132,7 @@ let ``empty list should be empty``() =
 let ``head should return``(x : obj) =
     let genAndName = unbox x 
     fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : BinomialHeap<int>), (l : int list)) ->    
-                                                                            (h.Head = l.Head)     
+                                                                            (h.Head() = l.Head)     
                                                                             |> classifyCollect h (h.Length())))
 [<Test>]
 let ``insert works``() =
@@ -168,28 +168,28 @@ let ``seq enumerate matches build list string``(x : obj) =
 let ``tail should return``(x : obj) =
     let genAndName = unbox x 
     fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : BinomialHeap<int>), (l : int list)) ->    
-                                                                            let tl = h.Tail
+                                                                            let tl = h.Tail()
                                                                             let tlHead =
-                                                                                if (tl.Length() > 0) then (tl.Head = l.Item(1))
+                                                                                if (tl.Length() > 0) then (tl.Head() = l.Item(1))
                                                                                 else true
                                                                             (tlHead && (tl.Length() = (l.Length - 1)))     
                                                                             |> classifyCollect h (h.Length())))
 
 [<Test>]
 let ``tryGetHead on empty should return None``() =
-    (BinomialHeap.empty true).TryGetHead |> should equal None
+    (BinomialHeap.empty true).TryGetHead() |> should equal None
 
 [<Test>]
 [<TestCaseSource("intGensStart2")>]
 let ``tryGetHead should return``(x : obj) =
     let genAndName = unbox x 
     fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : BinomialHeap<int>), (l : int list)) ->    
-                                                                            (h.TryGetHead.Value = l.Head)     
+                                                                            (h.TryGetHead().Value = l.Head)     
                                                                             |> classifyCollect h (h.Length())))
 
 [<Test>]
 let ``tryGetTail on empty should return None``() =
-    (BinomialHeap.empty true).TryGetTail |> should equal None
+    (BinomialHeap.empty true).TryGetTail() |> should equal None
 
 [<Test>]
 let ``tryGetTail on len 1 should return Some empty``() =
@@ -208,19 +208,19 @@ let ``tryMerge max and mis should be None``() =
 let ``tryUncons 1 element``(x : obj) =
     let genAndName = unbox x 
     fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : BinomialHeap<int>), (l : int list)) ->    
-                                                                            let x, tl = h.TryUncons.Value
+                                                                            let x, tl = h.TryUncons().Value
                                                                             ((x = l.Head) && (tl.Length() = (l.Length - 1)))     
                                                                             |> classifyCollect h (h.Length())))
 
 [<Test>]
 let ``tryUncons empty``() =
-    (BinomialHeap.empty true).TryUncons |> should equal None
+    (BinomialHeap.empty true).TryUncons() |> should equal None
 
 [<Test>]
 [<TestCaseSource("intGensStart2")>]
 let ``uncons 1 element``(x : obj) =
     let genAndName = unbox x 
     fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : BinomialHeap<int>), (l : int list)) ->    
-                                                                            let x, tl = h.Uncons
+                                                                            let x, tl = h.Uncons()
                                                                             ((x = l.Head) && (tl.Length() = (l.Length - 1)))     
                                                                             |> classifyCollect h (h.Length())))

--- a/tests/FSharpx.DataStructures.Tests/IQueueTest.fs
+++ b/tests/FSharpx.DataStructures.Tests/IQueueTest.fs
@@ -153,31 +153,31 @@ let ``fail if there is no tail in the queue``(eIQ : IQueue<obj>) =
 let ``fold matches build list rev``() =
 
     fsCheck "BatchedQueue" (Prop.forAll (Arb.fromGen QueueGen.batchedQueueIntGen) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
               
     fsCheck "BatchedQueue OfSeq" (Prop.forAll (Arb.fromGen QueueGen.batchedQueueIntOfSeqGen) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
 
     fsCheck "BatchedQueue Snoc" (Prop.forAll (Arb.fromGen QueueGen.batchedQueueIntSnocGen) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> BatchedQueue<int> |> BatchedQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
 
     fsCheck "HoodMelvilleQueue" (Prop.forAll (Arb.fromGen QueueGen.hoodMelvilleQueueIntGen) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> HoodMelvilleQueue<int> |> HoodMelvilleQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> HoodMelvilleQueue<int> |> HoodMelvilleQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
               
     fsCheck "HoodMelvilleQueue OfSeq" (Prop.forAll (Arb.fromGen QueueGen.hoodMelvilleQueueIntOfSeqGen) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> HoodMelvilleQueue<int> |> HoodMelvilleQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> HoodMelvilleQueue<int> |> HoodMelvilleQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
 
     fsCheck "HoodMelvilleQueue Snoc" (Prop.forAll (Arb.fromGen QueueGen.hoodMelvilleQueueIntSnocGen) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> HoodMelvilleQueue<int> |> HoodMelvilleQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> HoodMelvilleQueue<int> |> HoodMelvilleQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
 
     fsCheck "PhysicistQueue" (Prop.forAll (Arb.fromGen QueueGen.physicistQueueIntGen) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
               
     fsCheck "PhysicistQueue OfSeq" (Prop.forAll (Arb.fromGen (QueueGen.physicistQueueIntOfSeqGen)) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
 
     fsCheck "PhysicistQueue Snoc" (Prop.forAll (Arb.fromGen (QueueGen.physicistQueueIntSnocGen)) 
-        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q q.Length))
+        (fun ((q :IQueue<int>), (l : int list)) -> q :?> PhysicistQueue<int> |> PhysicistQueue.fold (fun (l' : int list) (elem : int) -> elem::l') [] = (List.rev l) |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("nonIQueue")>]
@@ -185,31 +185,31 @@ let ``fold matches build list rev``() =
 let ``foldback matches build list``() =
 
     fsCheck "BatchedQueue" (Prop.forAll (Arb.fromGen QueueGen.batchedQueueIntGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q (q.Length())))
               
     fsCheck "BatchedQueue OfSeq" (Prop.forAll (Arb.fromGen QueueGen.batchedQueueIntOfSeqGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q (q.Length())))
 
     fsCheck "BatchedQueue Snoc" (Prop.forAll (Arb.fromGen QueueGen.batchedQueueIntSnocGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> BatchedQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> BatchedQueue<int>) [] = l |> classifyCollect q (q.Length())))
 
     fsCheck "HoodMelvilleQueue" (Prop.forAll (Arb.fromGen QueueGen.hoodMelvilleQueueIntGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> HoodMelvilleQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> HoodMelvilleQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> HoodMelvilleQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> HoodMelvilleQueue<int>) [] = l |> classifyCollect q (q.Length())))
               
     fsCheck "HoodMelvilleQueue OfSeq" (Prop.forAll (Arb.fromGen QueueGen.hoodMelvilleQueueIntOfSeqGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> HoodMelvilleQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> HoodMelvilleQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> HoodMelvilleQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> HoodMelvilleQueue<int>) [] = l |> classifyCollect q (q.Length())))
 
     fsCheck "HoodMelvilleQueue Snoc" (Prop.forAll (Arb.fromGen QueueGen.hoodMelvilleQueueIntSnocGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> HoodMelvilleQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> HoodMelvilleQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> HoodMelvilleQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> HoodMelvilleQueue<int>) [] = l |> classifyCollect q (q.Length())))
 
     fsCheck "PhysicistQueue" (Prop.forAll (Arb.fromGen QueueGen.physicistQueueIntGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list)  -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q (q.Length())))
               
     fsCheck "PhysicistQueue OfSeq" (Prop.forAll (Arb.fromGen QueueGen.physicistQueueIntOfSeqGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q (q.Length())))
 
     fsCheck "PhysicistQueue Snoc" (Prop.forAll (Arb.fromGen QueueGen.physicistQueueIntSnocGen) 
-        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q q.Length))
+        (fun ((q : IQueue<int>), (l : int list)) -> PhysicistQueue.foldBack (fun (elem : int) (l' : int list) -> elem::l') (q :?> PhysicistQueue<int>) [] = l |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("IQueue")>]
@@ -217,7 +217,7 @@ let ``foldback matches build list``() =
 [<TestCaseSource("intGensStart1")>]
 let ``get head from queue``(x : obj) =
     let genAndName = unbox x 
-    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q.Head = (List.nth l 0) |> classifyCollect q q.Length))
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q.Head = (List.nth l 0) |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("IQueue")>]
@@ -225,7 +225,7 @@ let ``get head from queue``(x : obj) =
 [<TestCaseSource("intGensStart1")>]
 let ``get head from queue safely``(x : obj) =
     let genAndName = unbox x 
-    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q.TryGetHead.Value = (List.nth l 0) |> classifyCollect q q.Length))
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q.TryGetHead.Value = (List.nth l 0) |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("IQueue")>]
@@ -233,7 +233,7 @@ let ``get head from queue safely``(x : obj) =
 [<TestCaseSource("intGensStart2")>]
 let ``get tail from queue``(x : obj) =
     let genAndName = unbox x 
-    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((q : IQueue<int>), l) -> q.Tail.Head = (List.nth l 1) |> classifyCollect q q.Length))
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((q : IQueue<int>), l) -> q.Tail.Head = (List.nth l 1) |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("IQueue")>]
@@ -241,7 +241,7 @@ let ``get tail from queue``(x : obj) =
 [<TestCaseSource("intGensStart2")>]
 let ``get tail from queue safely``(x : obj) =
     let genAndName = unbox x 
-    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q : IQueue<int>, l) -> q.TryGetTail.Value.Head = (List.nth l 1) |> classifyCollect q q.Length))
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q : IQueue<int>, l) -> q.TryGetTail.Value.Head = (List.nth l 1) |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("IQueue")>]
@@ -263,7 +263,7 @@ let ``give None if there is no tail in the queue``(eIQ  : IQueue<obj>) =
 [<TestCaseSource("intGensStart1")>]
 let ``int queue builds and serializes``(x : obj) =
     let genAndName = unbox x 
-    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q |> Seq.toList = l |> classifyCollect q q.Length))
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<int>, l) -> q |> Seq.toList = l |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("IQueue")>]
@@ -271,7 +271,7 @@ let ``int queue builds and serializes``(x : obj) =
 [<TestCaseSource("objGens")>]
 let ``obj queue builds and serializes``(x : obj) =
     let genAndName = unbox x 
-    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<obj>, l) -> q |> Seq.toList = l |> classifyCollect q q.Length))
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<obj>, l) -> q |> Seq.toList = l |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("IQueue")>]
@@ -279,7 +279,7 @@ let ``obj queue builds and serializes``(x : obj) =
 [<TestCaseSource("stringGens")>]
 let ``string queue builds and serializes``(x : obj) =
     let genAndName = unbox x 
-    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<string>, l) -> q |> Seq.toList = l |> classifyCollect q q.Length))
+    fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun (q :IQueue<string>, l) -> q |> Seq.toList = l |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("nonIQueue")>]
@@ -287,13 +287,13 @@ let ``string queue builds and serializes``(x : obj) =
 let ``reverse . reverse = id``() =
 
     fsCheck "BankersQueue" (Prop.forAll (Arb.fromGen QueueGen.bankersQueueObjGen) 
-        (fun (q, l) -> q :?> BankersQueue<obj> |> BankersQueue.rev |> BankersQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q q.Length))
+        (fun (q, l) -> q :?> BankersQueue<obj> |> BankersQueue.rev |> BankersQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q (q.Length())))
     
     fsCheck "BatchedQueue" (Prop.forAll (Arb.fromGen QueueGen.batchedQueueObjGen) 
-        (fun (q, l) -> q :?> BatchedQueue<obj> |> BatchedQueue.rev |> BatchedQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q q.Length))
+        (fun (q, l) -> q :?> BatchedQueue<obj> |> BatchedQueue.rev |> BatchedQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q (q.Length())))
     
     fsCheck "PhysicistQueue" (Prop.forAll (Arb.fromGen QueueGen.physicistQueueIntGen) 
-        (fun (q, l) -> q :?> PhysicistQueue<int> |> PhysicistQueue.rev |> PhysicistQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q q.Length))
+        (fun (q, l) -> q :?> PhysicistQueue<int> |> PhysicistQueue.rev |> PhysicistQueue.rev |> Seq.toList = (q |> Seq.toList) |> classifyCollect q (q.Length())))
 
 [<Test>]
 [<Category("nonIQueue")>]

--- a/tests/FSharpx.DataStructures.Tests/LeftistHeapTest.fs
+++ b/tests/FSharpx.DataStructures.Tests/LeftistHeapTest.fs
@@ -20,13 +20,7 @@ Even restricting only to this type, never got generic element type 'a to work. N
 *)
 
 let insertThruList l h  =
-    let rec loop (h' : LeftistHeap<'a>) (l' : 'a list) = 
-        match l' with
-        | hd :: [] -> h'.Insert hd
-        | hd :: tl -> loop (h'.Insert hd) tl
-        | [] -> h' 
-        
-    loop h l
+    List.fold (fun (h' : #IHeap<_,'a>) x -> h'.Insert  x  ) h l
 
 (* LeftistHeap Gens *)
 let maxLeftistHeapIntGen =
@@ -229,19 +223,19 @@ let ``tryMerge max and mis should be None``() =
 let ``tryUncons 1 element``(x : obj) =
     let genAndName = unbox x 
     fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : LeftistHeap<int>), (l : int list)) ->    
-                                                                            let x, tl = h.TryUncons.Value
+                                                                            let x, tl = h.TryUncons().Value
                                                                             ((x = l.Head) && (tl.Length = (l.Length - 1)))     
                                                                             |> classifyCollect h h.Length))
 
 [<Test>]
 let ``tryUncons empty``() =
-    (LeftistHeap.empty true).TryUncons |> should equal None
+    (LeftistHeap.empty true).TryUncons() |> should equal None
 
 [<Test>]
 [<TestCaseSource("intGensStart2")>]
 let ``uncons 1 element``(x : obj) =
     let genAndName = unbox x 
     fsCheck (snd genAndName) (Prop.forAll (Arb.fromGen (fst genAndName)) (fun ((h : LeftistHeap<int>), (l : int list)) ->    
-                                                                            let x, tl = h.Uncons
+                                                                            let x, tl = h.Uncons()
                                                                             ((x = l.Head) && (tl.Length = (l.Length - 1)))     
                                                                             |> classifyCollect h h.Length))


### PR DESCRIPTION
1) IQueue Length() -- queues still to be brought onto interface have
O(log n) length
2) IHeap - major functions are O(log n) for most heaps
3) LeftistHeap - major functions except Head are O(log n)
4) BinomialHeap - major functions are O(log n)
