### PR TITLE
Add GetOrDefault for option in C#

### DIFF
--- a/src/FSharpx.Core/CSharpCompat.fs
+++ b/src/FSharpx.Core/CSharpCompat.fs
@@ -197,6 +197,12 @@ type FSharpOption =
         | _ -> other.Invoke()
 
     [<Extension>]
+    static member GetOrDefault (o: Option<_>) =
+        match o with
+        | Some x -> x
+        | _ -> Unchecked.defaultof<_>
+
+    [<Extension>]
     static member ToFSharpChoice (o, other) =
         match o with
         | Some v -> Choice1Of2 v

--- a/tests/FSharpx.CSharpTests/OptionTests.cs
+++ b/tests/FSharpx.CSharpTests/OptionTests.cs
@@ -225,6 +225,22 @@ namespace FSharpx.CSharpTests {
         }
 
         [Test]
+        public void GetOrDefault_ReferenceType()
+        {
+            var a = FSharpOption<string>.None;
+            var b = a.GetOrDefault();
+            Assert.AreEqual(null, b);
+        }
+
+        [Test]
+        public void GetOrDefault_ValueType()
+        {
+            var a = FSharpOption<int>.None;
+            var b = a.GetOrDefault();
+            Assert.AreEqual(0, b);
+        }
+
+        [Test]
         public void Sequence_Some() {
             var r = FSharpList.Create(1.Some(), 2.Some(), 3.Some()).Sequence();
             Assert.AreEqual(FSharpList.Create(1,2,3).Some(), r);


### PR DESCRIPTION
Provides an easy way to get null (or default value for type) from an empty option via C# (issue #67).

My first attempt at F#, so not sure if this is usable.
