### PR TITLE
Make the JSON date parser be more robust for the mac.

### DIFF
--- a/src/FSharpx.Core/JSON.fs
+++ b/src/FSharpx.Core/JSON.fs
@@ -236,10 +236,14 @@ let parse source =
             |> (new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).AddMilliseconds 
             |> (fun x -> Date(x))
         else
+            let dateTimeStylesForUtc = function
+                | true -> DateTimeStyles.AssumeUniversal ||| DateTimeStyles.AdjustToUniversal
+                | false -> DateTimeStyles.AssumeLocal ||| DateTimeStyles.AllowWhiteSpaces
+                
             let matches = iso8601Regex.Match(input)
             if matches.Success then
                 input 
-                |> fun s -> DateTime.TryParse(s, CultureInfo.InvariantCulture, (if matches.Groups.["IsUTC"].Success then DateTimeStyles.AssumeUniversal ||| DateTimeStyles.AdjustToUniversal else DateTimeStyles.AssumeLocal))
+                |> fun s -> DateTime.TryParse(s, CultureInfo.InvariantCulture, dateTimeStylesForUtc matches.Groups.["IsUTC"].Success)
                 |> (fun (parsed, d) -> if parsed then 
                                          Date(d)
                                        else

--- a/tests/FSharpx.Tests/JSON.Tests.fs
+++ b/tests/FSharpx.Tests/JSON.Tests.fs
@@ -63,6 +63,11 @@ let ``Can parse document with UTC iso date``() =
     let j = parse "{\"anniversary\": \"2009-05-19 14:39:22Z\"}"
     (j.GetDate "anniversary").ToUniversalTime() |> should equal (new System.DateTime(2009, 05, 19, 14, 39, 22, System.DateTimeKind.Utc))
     (j.GetDate "anniversary").Kind |> should equal System.DateTimeKind.Utc
+
+[<Test>]    
+let ``Can parse document with timezone and fraction iso date``() =
+    let j = parse "{\"anniversary\": \"1997-07-16T19:20:30.45+01:00\"}"
+    (j.GetDate "anniversary").ToUniversalTime() |> should equal (new System.DateTime(1997, 07, 16, 18, 20, 30, 450, System.DateTimeKind.Utc))
     
 // TODO: Due to limitations in the current ISO 8601 datetime parsing these fail, and should be made to pass
 //[<Test>]


### PR DESCRIPTION
the JSON parsing seems a little unfinished, there are even two unit tests commented out.

I added  an additional DateTimeStyle, so that the DateTime.TryParse also works on mac.
