### PR TITLE
Add a computation expression for choice.

### DIFF
--- a/src/FSharpx.Core/ComputationExpressions/Monad.fs
+++ b/src/FSharpx.Core/ComputationExpressions/Monad.fs
@@ -742,24 +742,6 @@ module Choice =
         member this.Return a = returnM a
         member this.Bind (m, f) = bind f m
         member this.ReturnFrom m = m
-        member this.Zero () = returnM ()
-        member this.Combine (m, f)  = bind f m
-        member this.Delay f = f
-        member this.Run f = f ()
-        member this.TryWith (m, h) =
-            try this.ReturnFrom m
-            with e -> h e
-        member this.TryFinally (m, compensation) =
-            try this.ReturnFrom m
-            finally compensation()
-        member this.Using (resource : #IDisposable, body) = 
-            this.TryFinally (body resource, fun () -> match resource with null -> () | disp -> disp.Dispose())
-        member this.While (guard, f) = 
-            if not (guard()) then this.Zero() else
-            this.Bind(f(), fun _ -> this.While(guard, f))
-        member this.For (sequence:seq<_>, body) =
-            this.Using (sequence.GetEnumerator(),
-                        fun enum -> this.While(enum.MoveNext, this.Delay(fun () -> body enum.Current)))
 
     let choose = EitherBuilder()
 


### PR DESCRIPTION
There was a computation expression for choice, the EitherBuilder, but it was a bit meager and there was not instance of the builder.

I mostly copied the MaybeBuilder, with one change (and I think, that one is maybe a suble bug?):
Zero is implemented as Choice1Of2 (), as opposed to None in the MaybeBuilder.

Is it actually inteded for the computation to abort, just because someone calls Zero? Isn't zero just a valid, empty, value? And if it should break the computation, what would be a reasonable zero for Choice then?

Please review if the semantics make sense. I tried playing with it in FSI and it looks reasonable.
