### PR TITLE
Helper scripts for testing type providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,9 @@ docs/
 nuget/
 test/
 FSharp.Monad_mm_cache.bin
-
 *.orig
 *.nupkg
 manualNuget/lib/
 build.AndDeploy.bat
 *.sln.ide
+__setup__.fsx

--- a/src/FSharpx.TypeProviders.AppSettings/AppSettingsProvider.fs
+++ b/src/FSharpx.TypeProviders.AppSettings/AppSettingsProvider.fs
@@ -24,7 +24,7 @@ let (|Double|_|) text =
     | _ -> None
 
 
-let internal typedAppSettings (cfg:TypeProviderConfig) =
+let internal typedAppSettings (ownerType:TypeProviderForNamespaces) (cfg:TypeProviderConfig) =
     let appSettings = erasedType<obj> thisAssembly rootNamespace "AppSettings"
 
     appSettings.DefineStaticParameters(
@@ -63,7 +63,7 @@ let internal typedAppSettings (cfg:TypeProviderConfig) =
 type public FSharpxProvider(cfg:TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces()
 
-    do this.AddNamespace(rootNamespace,[typedAppSettings cfg])
+    do this.AddNamespace(rootNamespace, [typedAppSettings this cfg])
 
 [<TypeProviderAssembly>]
 do ()

--- a/src/FSharpx.TypeProviders.AppSettings/FSharpx.TypeProviders.AppSettings.fsproj
+++ b/src/FSharpx.TypeProviders.AppSettings/FSharpx.TypeProviders.AppSettings.fsproj
@@ -56,6 +56,7 @@
       <Link>TypeProvider.Helper.fs</Link>
     </Compile>
     <Compile Include="AppSettingsProvider.fs" />
+    <None Include="TestAppSettingsProvider.fsx" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/src/FSharpx.TypeProviders.AppSettings/TestAppSettingsProvider.fsx
+++ b/src/FSharpx.TypeProviders.AppSettings/TestAppSettingsProvider.fsx
@@ -1,0 +1,12 @@
+﻿#load "../FSharpx.TypeProviders/SetupTesting.fsx"
+SetupTesting.setup __SOURCE_DIRECTORY__
+#load "__setup__.fsx"
+
+open System.IO
+open FSharpx.TypeProviders.Helper
+open FSharpx.TypeProviders.AppSettingsTypeProvider
+
+let (++) a b = Path.Combine(a, b)
+let resolutionFolder = __SOURCE_DIRECTORY__ ++ ".." ++ ".." ++ "tests" ++ "FSharpx.TypeProviders.AppSettings.Tests"
+
+generate typedAppSettings resolutionFolder [| "Test.App.Config" |] |> prettyPrint

--- a/src/FSharpx.TypeProviders.Documents/FSharpx.TypeProviders.Documents.fsproj
+++ b/src/FSharpx.TypeProviders.Documents/FSharpx.TypeProviders.Documents.fsproj
@@ -66,6 +66,7 @@
     <Compile Include="JsonProvider.fs" />
     <Compile Include="MiniCsvProvider.fs" />
     <Compile Include="NamespaceProvider.fs" />
+    <None Include="TestDocumentProviders.fsx" />
   </ItemGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>

--- a/src/FSharpx.TypeProviders.Documents/TestDocumentProviders.fsx
+++ b/src/FSharpx.TypeProviders.Documents/TestDocumentProviders.fsx
@@ -1,0 +1,41 @@
+﻿#load "../FSharpx.TypeProviders/SetupTesting.fsx"
+SetupTesting.setup __SOURCE_DIRECTORY__
+#load "__setup__.fsx"
+
+open System.IO
+open FSharpx.TypeProviders.Helper
+open FSharpx.TypeProviders.MiniCsvProvider
+open FSharpx.TypeProviders.JsonTypeProvider
+open FSharpx.TypeProviders.XmlTypeProvider
+
+let (++) a b = Path.Combine(a, b)
+let resolutionFolder = __SOURCE_DIRECTORY__ ++ ".." ++ ".." ++ "tests" ++ "FSharpx.TypeProviders.Documents.Tests"
+
+let schema = 
+        """{  
+                 "firstName": "John",
+                 "lastName" : "Smith",
+                 "age"      : 25,
+                 "address"  :
+                 {
+                     "streetAddress": "21 2nd Street",
+                     "city"         : "New York",
+                     "state"        : "NY",
+                     "postalCode"   : "10021"
+                 },
+                 "phoneNumber":
+                 [
+                     {
+                       "type"  : "home",
+                       "number": "212 555-1234"
+                     },
+                     {
+                       "type"  : "fax",
+                       "number": "646 555-4567"
+                     }
+                 ]
+             }"""
+
+generate jsonType resolutionFolder [| "@@@missingValue###"; schema |] |> prettyPrint
+generate csvType resolutionFolder [| "SmallTest.csv" |] |> prettyPrint
+generate xmlType resolutionFolder [| "Philosophy.xml"; "@@@missingValue###" |] |> prettyPrint

--- a/src/FSharpx.TypeProviders/FSharpx.TypeProviders.fsproj
+++ b/src/FSharpx.TypeProviders/FSharpx.TypeProviders.fsproj
@@ -46,6 +46,7 @@
       <Link>Strings.fs</Link>
     </Compile>
     <Compile Include="TypeProvider.Helper.fs" />
+    <None Include="SetupTesting.fsx" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Data.TypeProviders, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/FSharpx.TypeProviders/ProvidedTypes.fsi
+++ b/src/FSharpx.TypeProviders/ProvidedTypes.fsi
@@ -318,6 +318,8 @@ type internal ProvidedTypeDefinition =
     [<Experimental("SuppressRelocation is a workaround and likely to be removed")>]
     member SuppressRelocation : bool  with get,set
 
+    member MakeParametricType : name:string * args:obj[] -> ProvidedTypeDefinition
+
 /// A provided generated assembly
 type ProvidedAssembly =
     new : assemblyFileName:string -> ProvidedAssembly

--- a/src/FSharpx.TypeProviders/SetupTesting.fsx
+++ b/src/FSharpx.TypeProviders/SetupTesting.fsx
@@ -1,0 +1,39 @@
+﻿#r "System.Xml.Linq"
+
+open System
+open System.IO
+open System.Xml.Linq
+
+let setup dir = 
+    let proj = Directory.GetFiles(dir, "*.fsproj") |> Seq.head
+
+    let getElemName name = XName.Get(name, "http://schemas.microsoft.com/developer/msbuild/2003")
+
+    let getElemValue name (parent:XElement) =
+        let elem = parent.Element(getElemName name)
+        if elem = null || String.IsNullOrEmpty elem.Value then None else Some(elem.Value)
+    
+    let getAttrValue name (elem:XElement) =
+        let attr = elem.Attribute(XName.Get name)
+        if attr = null || String.IsNullOrEmpty attr.Value then None else Some(attr.Value)
+
+    let (|??) (option1: 'a Option) option2 =
+        if option1.IsSome then option1 else option2
+
+    let fsProjFile = Directory.GetFiles(dir, "*.fsproj") |> Seq.head
+    let fsProjXml = XDocument.Load fsProjFile
+
+    let refs = 
+        fsProjXml.Document.Descendants(getElemName "Reference")
+        |> Seq.choose (fun elem -> getElemValue "HintPath" elem |?? getAttrValue "Include" elem)
+        |> Seq.map (fun ref -> "#r \"" + ref.Replace(@"\", @"\\") + "\"")
+        |> Seq.toList
+
+    let fsFiles = 
+        fsProjXml.Document.Descendants(getElemName "Compile")
+        |> Seq.choose (fun elem -> getAttrValue "Include" elem)
+        |> Seq.map (fun fsFile -> "#load \"" + fsFile + "\"")
+        |> Seq.toList
+    
+    let tempFile = Path.Combine(dir, "__setup__.fsx")
+    File.WriteAllLines(tempFile, refs @ fsFiles)    

--- a/src/FSharpx.TypeProviders/TypeProvider.Helper.fs
+++ b/src/FSharpx.TypeProviders/TypeProvider.Helper.fs
@@ -33,3 +33,99 @@ let watchForChanges (ownerType:TypeProviderForNamespaces) (fileName:string) =
 // Get the assembly and namespace used to house the provided types
 let thisAssembly = System.Reflection.Assembly.GetExecutingAssembly()
 let rootNamespace = "FSharpx"
+
+
+open System.Collections.Generic
+open System.Reflection
+open System.Text
+open Microsoft.FSharp.Core.CompilerServices
+open FSharpx.Strings
+
+let generate typeProviderConstructor (resolutionFolder : string) (args: string array) =
+    let cfg = new TypeProviderConfig(fun _ -> false)
+    cfg.GetType().GetProperty("ResolutionFolder").GetSetMethod(nonPublic = true).Invoke(cfg, [| box resolutionFolder |]) |> ignore
+
+    let typeProviderForNamespaces = new TypeProviderForNamespaces() 
+    let genericTypeDefinition : ProvidedTypeDefinition = 
+        typeProviderConstructor typeProviderForNamespaces cfg    
+
+    let typeName = genericTypeDefinition.Name + (args |> Seq.map (fun s -> ",\"" + s + "\"") |> Seq.reduce (+))
+    let concreteTypeDefinition = genericTypeDefinition.MakeParametricType(typeName, args |> Array.map box)
+
+    concreteTypeDefinition
+
+let prettyPrint t =        
+
+    let pending = new Queue<_>()
+    let visited = new HashSet<_>()
+
+    let rec toString (t: Type) =
+        match t with
+        | t when t = typeof<obj> -> "obj"
+        | t when t = typeof<int> -> "int"
+        | t when t = typeof<int64> -> "int64"
+        | t when t = typeof<float> -> "float"
+        | t when t = typeof<float32> -> "float32"
+        | t when t = typeof<string> -> "string"
+        | t when t = typeof<Void> -> "()"
+        | t when t = typeof<unit> -> "()"
+        | :? ProvidedTypeDefinition as t ->
+            if visited.Add t then
+                pending.Enqueue t
+            t.Name.Split([| ',' |]).[0]
+        | t when t.IsGenericType ->            
+            let args = 
+                t.GetGenericArguments() 
+                |> Seq.map toString
+                |> separatedBy ", "
+            let name = 
+                if t.Name.Contains("[") then  // units of measure
+                    toString t.UnderlyingSystemType
+                else 
+                    t.Name
+            name.Split([| '`' |]).[0] + "<" + args + ">"
+        | t -> t.Name
+
+    let toSignature (parameters: ParameterInfo[]) =
+        if parameters.Length = 0 then
+            "()"
+        else
+            parameters 
+            |> Seq.map (fun p -> p.Name + ":" + (toString p.ParameterType))
+            |> separatedBy " -> "
+
+    let sb = StringBuilder ()
+    let print (str: string) =
+        sb.Append(str) |> ignore
+    let println() =
+        sb.AppendLine() |> ignore
+                
+    let printMember (memberInfo: MemberInfo) =        
+        let print str =
+            print "    "                
+            print str
+            println()
+        match memberInfo with
+        | :? ProvidedConstructor as cons -> 
+            print <| "new : " + (toSignature <| cons.GetParameters()) + " -> " + (toString memberInfo.DeclaringType)
+        | :? ProvidedLiteralField as field -> 
+            print <| "val " + field.Name + ": " + (toString field.FieldType) + " - " + (field.GetRawConstantValue().ToString())
+        | :? ProvidedProperty as prop -> 
+            print <| "member " + prop.Name + ": " + (toString prop.PropertyType) + " with " + (if prop.CanRead && prop.CanWrite then "get, set" else if prop.CanRead then "get" else "set")
+        | :? ProvidedMethod as m ->
+            if m.Attributes &&& MethodAttributes.SpecialName <> MethodAttributes.SpecialName then
+                print <| "member " + m.Name + ": " + (toSignature <| m.GetParameters()) + " -> " + (toString m.ReturnType)
+        | :? ProvidedTypeDefinition as t -> if visited.Add t then pending.Enqueue t  
+        | _ -> ()
+
+    pending.Enqueue t
+    visited.Add t |> ignore
+
+    while pending.Count <> 0 do
+        let t = pending.Dequeue()
+        print (toString t)
+        println()
+        t.GetMembers() |> Seq.iter printMember
+        println()
+    
+    sb.ToString()


### PR DESCRIPTION
Launching VisualStudio with the debgger attached everytime we want to test a type provider can be a little bit slow
This scripts allow to debug the generated types
It still needs some work before it can be used on the Freebase type provider, but for the AppSettings, Json, XML, and CSV it already works well

PS: For this to work, we can't send the whole fsx to fsi at once. The first two lines:

```
#load "../FSharpx.TypeProviders/SetupTesting.fsx"
SetupTesting.setup __SOURCE_DIRECTORY__
```

always have to be sent to the fsi, then the third line:

```
 #load "__setup__.fsx"
```

and only then the rest can be sent
