### PR TITLE
Fix #184

### DIFF
--- a/src/FSharpx.TypeProviders.AppSettings/AppSettingsProvider.fs
+++ b/src/FSharpx.TypeProviders.AppSettings/AppSettingsProvider.fs
@@ -45,7 +45,7 @@ let internal typedAppSettings (ownerType:TypeProviderForNamespaces) (cfg:TypePro
                             | Int fieldValue ->    ProvidedLiteralField(niceName key, typeof<int>, fieldValue)
                             | Bool fieldValue ->   ProvidedLiteralField(niceName key, typeof<bool>, fieldValue)
                             | Double fieldValue -> ProvidedLiteralField(niceName key, typeof<float>, fieldValue)
-                            | fieldValue ->        ProvidedLiteralField(niceName key, typeof<obj>, fieldValue)
+                            | fieldValue ->        ProvidedLiteralField(niceName key, typeof<string>, fieldValue)
 
                         field.AddXmlDoc (sprintf "Returns the value from %s with key %s" configFileName key)
                         field.AddDefinitionLocation(1,1,configFileName)


### PR DESCRIPTION
There was already a test verifying it was a string, but the way we're testing is by calling the .GetType on the value of the property, which passed. To be able to test it properly we would need use reflection to verify the type of the property, but I think it would be overkill.
Alternatively, we could have some tests that used the generate and prettyPrint methods from TypeProvider.Helpers to compare the full signature of the generated types, that's how I found the bug.
