### PR TITLE
Removed spurious TypeProviderAssembly attribute

### DIFF
--- a/src/FSharpx.TypeProviders.Management.DesignTime/WmiProvider.DesignTime.fs
+++ b/src/FSharpx.TypeProviders.Management.DesignTime/WmiProvider.DesignTime.fs
@@ -435,6 +435,3 @@ type public WmiExtender(config : TypeProviderConfig) as this =
         t
 
     do this.AddNamespace(rootNamespace, [remoteType])
-
-[<assembly:TypeProviderAssembly>]
-do()


### PR DESCRIPTION
This attribute was preventing compiled applications from using the WMI
type provider.
