### PR TITLE
Haskell style maybe operator in prelude

### DIFF
--- a/src/FSharpx.Core/Prelude.fs
+++ b/src/FSharpx.Core/Prelude.fs
@@ -134,3 +134,8 @@ module Prelude =
     let (|Boolean|_|) = Boolean.parse
     let (|Int32|_|) = Int32.parse
     let (|Double|_|) = Double.parse
+
+    /// Haskell-style maybe operator
+    let maybe (defaultValue : 'b) (map : 'a -> 'b) = function
+        | None   -> defaultValue
+        | Some a -> map a


### PR DESCRIPTION
I really like Haskells maybe operator (see http://hackage.haskell.org/packages/archive/base/latest/doc/html/Prelude.html#v:maybe) so I added it to the prelude.

In case you do not know it - you can think of it as a "Default-Value-For-Option":

``` fsharp
let maybe (defaultValue : 'b) (map : 'a -> 'b) = function
  | None   -> defaultValue
  | Some a -> map a 
```

and a example could be:

``` fsharp
let absOrZero = maybe 0 abs
absOrZero None      // <- yields 0
absOrZero (Some -5) // <- yields 5
```
