### PR TITLE
hopefully fixes a Bug with CancellationToken.Register

### DIFF
--- a/src/FSharpx.Core/Observable.fs
+++ b/src/FSharpx.Core/Observable.fs
@@ -280,7 +280,8 @@ module Observable =
         async {
             let! cToken = Async.CancellationToken
             let token : CancellationToken = cToken
-            use registration = token.Register(fun () -> remove())
+            let action = new Action(remove)
+            use registration = token.Register(action)
             return! workflow
         })
 
@@ -316,7 +317,8 @@ module Observable =
         async {
             let! cToken = Async.CancellationToken
             let token : CancellationToken = cToken
-            use registration = token.Register(fun () -> remove())
+            let action = new Action(remove)
+            use registration = token.Register(action)
             return! workflow
         })
   


### PR DESCRIPTION
I now wrapped the function I want to run on Cancellation into an Action-object 
On my local machine everything compiles and the test all turns green (ok-there is one "yellow" - not mine though)
