### PR TITLE
fixed an issue with CancellationToken not there in NET35

### DIFF
--- a/src/FSharpx.Core/Observable.fs
+++ b/src/FSharpx.Core/Observable.fs
@@ -280,8 +280,11 @@ module Observable =
         async {
             let! cToken = Async.CancellationToken
             let token : CancellationToken = cToken
-            let action = new Action(remove)
-            use registration = token.Register(action)
+            #if NET40
+            use registration = token.Register(fun () -> remove())
+            #else
+            use registration = token.Register((fun _ -> remove()), null)
+            #endif
             return! workflow
         })
 
@@ -317,8 +320,11 @@ module Observable =
         async {
             let! cToken = Async.CancellationToken
             let token : CancellationToken = cToken
-            let action = new Action(remove)
-            use registration = token.Register(action)
+            #if NET40
+            use registration = token.Register(fun () -> remove())
+            #else
+            use registration = token.Register((fun _ -> remove()), null)
+            #endif
             return! workflow
         })
   


### PR DESCRIPTION
ok ... here is the long story:

I use CancellationToken.Register to get a hook into the cancellation of the async-workflow but in .NET 3.5 there was no CancellationToken (neither was some other stuff) - but I guess the F# team was somewhat ahead of the official release and packed a version into FSharp.Core ... sadly this version had a single overload taking two arguments: just like the usual async-continuations it took an action (wanting a state argument) and the state that should be passed to that action.

I hopefully addressed the issue by #if - branching on the used framework (NET40 or not)

Sorry ... that is some stuff I just never had to see before ... you got to love the FSharp 3.0 vs 2.0 stuff ... 
