### PR TITLE
Vector.initial, RandomAccessList.tail bug

### DIFF
--- a/src/FSharpx.Core/Collections/RandomAccessList.fsi
+++ b/src/FSharpx.Core/Collections/RandomAccessList.fsi
@@ -31,10 +31,10 @@ type RandomAccessList<[<EqualityConditionalOn>]'T when 'T : equality> =
     ///O(n). Returns random access list reversed.
     member Rev : unit -> RandomAccessList<'T>
 
-    /// O(1). Returns a new random access list without the last item. If the collection is empty it throws an exception.
+    /// O(n). Returns a new random access list without the last item. If the collection is empty it throws an exception.
     member Tail : RandomAccessList<'T>
 
-    /// O(1). Returns option random access list without the last item.
+    /// O(n). Returns option random access list without the last item.
     member TryTail : RandomAccessList<'T> option
 
     /// O(1). Returns tuple last element and random access list without last item  
@@ -97,10 +97,10 @@ module RandomAccessList =
     ///O(n). Returns new random access list reversed.
     val inline rev : RandomAccessList<'T> -> RandomAccessList<'T>
 
-    /// O(1). Returns a new random access list without the last item. If the collection is empty it throws an exception.
+    /// O(n). Returns a new random access list without the last item. If the collection is empty it throws an exception.
     val inline tail : RandomAccessList<'T> -> RandomAccessList<'T>
 
-    /// O(1). Returns option random access list without the last item.
+    /// O(n). Returns option random access list without the last item.
     val inline tryTail : RandomAccessList<'T> -> RandomAccessList<'T> option
 
     /// O(1). Returns tuple last element and random access list without last item

--- a/src/FSharpx.Core/Collections/Vector.fsi
+++ b/src/FSharpx.Core/Collections/Vector.fsi
@@ -14,10 +14,10 @@ type Vector<[<EqualityConditionalOn>]'T when 'T : equality> =
     /// O(1). Returns a new vector with the element added at the end.
     member Conj : 'T -> Vector<'T>
          
-    /// O(1). Returns a new vector without the last item. If the collection is empty it throws an exception.
+    /// O(n). Returns a new vector without the last item. If the collection is empty it throws an exception.
     member Initial : Vector<'T>
 
-    /// O(1). Returns option vector without the last item.
+    /// O(n). Returns option vector without the last item.
     member TryInitial : Vector<'T> option
 
     /// O(1). Returns true if the vector has no elements.
@@ -74,10 +74,10 @@ module Vector =
     /// O(n). Returns a vector of the supplied length using the supplied function operating on the index. 
     val init : int -> (int -> 'T) -> Vector<'T>
 
-    /// O(1). Returns a new vector without the last item. If the collection is empty it throws an exception.
+    /// O(n). Returns a new vector without the last item. If the collection is empty it throws an exception.
     val inline initial : Vector<'T> -> Vector<'T>
 
-    /// O(1). Returns option vector without the last item.
+    /// O(n). Returns option vector without the last item.
     val inline tryInitial : Vector<'T> -> Vector<'T> option
 
     /// O(1). Returns true if the vector has no elements.

--- a/tests/FSharpx.Collections.Tests/RandomAccessListTest.fs
+++ b/tests/FSharpx.Collections.Tests/RandomAccessListTest.fs
@@ -262,6 +262,21 @@ let ``tryTail on len 2 should return``() =
     ((head a.Value) = 1) |> should equal true
 
 [<Test>]
+let ``randomAccessList of randomAccessLists constructed by consing tail``() =
+
+    let windowFun windowLength = 
+        fun (v : RandomAccessList<RandomAccessList<int>>) t ->
+        if v.Head.Length = windowLength then RandomAccessList.cons (RandomAccessList.empty.Cons(t)) v
+        else RandomAccessList.tail v |> RandomAccessList.cons (RandomAccessList.cons t (RandomAccessList.head v))
+
+    let windowed = 
+        seq{1..100}
+        |> Seq.fold (windowFun 5) (RandomAccessList.empty.Cons RandomAccessList.empty<int>)
+
+    windowed.Length |> should equal 20
+    windowed.[2].Length |> should equal 5
+
+[<Test>]
 let ``nth length 1``() =
     let x = empty |> cons "a" 
 //    let x = empty |> cons "a" 

--- a/tests/FSharpx.Collections.Tests/VectorTest.fs
+++ b/tests/FSharpx.Collections.Tests/VectorTest.fs
@@ -204,6 +204,23 @@ let ``can get initial elements from a vector``() =
     vector |> initial |> length |> should equal 2
     vector |> initial |> initial |> length |> should equal 1
 
+
+[<Test>]
+let ``vector of vectors constructed by conjing initial``() =
+
+    let windowFun windowLength = 
+        fun (v : Vector<Vector<int>>) t ->
+        if v.Last.Length = windowLength then Vector.conj (Vector.empty.Conj(t)) v
+        else Vector.initial v |> Vector.conj (Vector.conj t (Vector.last v))
+
+    let windowed = 
+        seq{1..100}
+        |> Seq.fold (windowFun 5) (Vector.empty.Conj Vector.empty<int>)
+
+    windowed.Length |> should equal 20
+    windowed.[2].Length |> should equal 5
+        
+
 [<Test>]
 let ``vector with 300 elements should allow initial``() =
     let vector = ref empty


### PR DESCRIPTION
1) Vector from initial cannot conj and RandomAccessList from tail cannot
cons under certain circumstances
2) added covering unit tests
