### PR TITLE
Fast reflection operations

### DIFF
--- a/FSharpx.Core.Tests/FSharpx.Core.Tests.fsproj
+++ b/FSharpx.Core.Tests/FSharpx.Core.Tests.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="AwaitHelpers.fs" />
     <Compile Include="AwaitObservableTests.fs" />
     <Compile Include="OptionTests.fs" />
+    <Compile Include="ReflectionTests.fs" />
     <None Include="packages.config" />
     <None Include="app.config" />
   </ItemGroup>

--- a/FSharpx.Core.Tests/ReflectionTests.fs
+++ b/FSharpx.Core.Tests/ReflectionTests.fs
@@ -1,0 +1,318 @@
+﻿namespace FSharpx.Core.Tests
+  
+module ReflectionRecordTest =
+
+    open NUnit.Framework
+    open Microsoft.FSharp.Reflection
+    open System.Reflection //for bindingflags
+
+    //some test types
+
+    type Straightforward =
+            { S : string
+              I : int
+              F : float
+              O : obj } //object is somewhat special cased the constructor code
+
+    type Mutable =
+        { mutable Sm : string
+          mutable Im : int
+          mutable Fm : float }
+
+    type internal Internal = internal { Si : string }
+
+    type private Private = private { Fp : float }
+
+    type Generic<'a> = { Generic : 'a }
+
+
+    [<Test>]
+    let ``should construct Straightforward record``() =
+        let ctor = FSharpValue.PreComputeRecordConstructorFast(typeof<Straightforward>)
+        let data = [| box "string"; box 12; box 15.12; new obj() |]
+
+        let result = ctor data
+        Assert.IsInstanceOf(typeof<Straightforward>, result)
+        let primResult = result :?> Straightforward
+        Assert.AreEqual("string", primResult.S)
+        Assert.AreEqual(12, primResult.I)
+        Assert.AreEqual(15.12, primResult.F)
+        Assert.AreEqual(data.[3], primResult.O)
+
+
+    [<Test>]
+    let ``should read Straightforward record``() =
+        let dtor = FSharpValue.PreComputeRecordReaderFast typeof<Straightforward>        
+        let data = { S = "string"; I = 12; F = 15.12; O = new obj() }
+
+        let result = dtor data
+        Assert.AreEqual(data.S, unbox<string> result.[0])
+        Assert.AreEqual(data.I, unbox<int> result.[1])
+        Assert.AreEqual(data.F, unbox<float> result.[2])
+        Assert.AreSame(data.O, result.[3])
+
+    [<Test>]
+    let ``should construct Mutable record``() =
+        let ctor = FSharpValue.PreComputeRecordConstructorFast(typeof<Mutable>)
+        let data = [| box "string"; box 12; box 15.12 |]
+
+        let result = ctor data
+        let primResult = result :?> Mutable
+        Assert.AreEqual("string", primResult.Sm)
+        Assert.AreEqual(12, primResult.Im)
+        Assert.AreEqual(15.12, primResult.Fm)
+
+
+    [<Test>]
+    let ``should read Mutable record``() =
+        let dtor = FSharpValue.PreComputeRecordReaderFast typeof<Mutable>        
+        let data = { Sm = "string"; Im = 12; Fm = 15.12 }
+
+        let result = dtor data
+        Assert.AreEqual(data.Sm, unbox<string> result.[0])
+        Assert.AreEqual(data.Im, unbox<int> result.[1])
+        Assert.AreEqual(data.Fm, unbox<float> result.[2])
+
+    [<Test>]
+    let ``should construct Internal record``() =
+        let ctor = FSharpValue.PreComputeRecordConstructorFast(typeof<Internal>, BindingFlags.NonPublic)
+        let data = [| box "string" |]
+
+        let result = ctor data
+        let primResult = result :?> Internal
+        Assert.AreEqual("string", primResult.Si)
+
+
+    [<Test>]
+    let ``should read Internal record``() =
+        let dtor = FSharpValue.PreComputeRecordReaderFast(typeof<Internal>, BindingFlags.NonPublic)
+        let data = { Si = "string" }
+
+        let result = dtor data
+        Assert.AreEqual(data.Si, unbox<string> result.[0])
+
+    [<Test>]
+    let ``should construct Private record``() =
+        let ctor = FSharpValue.PreComputeRecordConstructorFast(typeof<Private>, BindingFlags.NonPublic)
+        let data = [| box 1.2 |]
+
+        let result = ctor data
+        let primResult = result :?> Private
+        Assert.AreEqual(1.2, primResult.Fp)
+
+
+    [<Test>]
+    let ``should read Private record``() =
+        let dtor = FSharpValue.PreComputeRecordReaderFast(typeof<Private>, BindingFlags.NonPublic)
+        let data = { Fp = 2.1 }
+
+        let result = dtor data
+        Assert.AreEqual(data.Fp, unbox<float> result.[0])
+
+    [<Test>]
+    let ``should construct Generic record``() =
+        let ctor = FSharpValue.PreComputeRecordConstructorFast(typeof<Generic<int>>)
+        let data = [| box 1 |]
+
+        let result = ctor data :?> Generic<int>
+        Assert.AreEqual(1, result.Generic)
+
+
+    [<Test>]
+    let ``should read Generic record``() =
+        let dtor = FSharpValue.PreComputeRecordReaderFast(typeof<Generic<int>>)
+        let data = { Generic = 2 }
+
+        let result = dtor data
+        Assert.AreEqual(data.Generic, unbox<int> result.[0])
+        
+module ReflectionUnionTest =
+
+    open NUnit.Framework
+    open Microsoft.FSharp.Reflection
+    open System.Reflection //for bindingflags
+
+    type Straightforward =
+        | Empty
+        | S of string
+        | I of int * string
+
+    type Singleton = Single
+
+    type internal Internal = internal | Si of string
+
+    type internal Private = private | Fp of float
+
+    type Generic<'a> = | Generic of 'a
+
+    let straightforwardCases = FSharpType.GetUnionCases typeof<Straightforward>
+    let singletonCase = (FSharpType.GetUnionCases typeof<Singleton>).[0]
+    let internalCase = (FSharpType.GetUnionCases(typeof<Internal>, BindingFlags.NonPublic)).[0]
+    let privateCase = (FSharpType.GetUnionCases(typeof<Private>, BindingFlags.NonPublic)).[0]
+    let genericCase = (FSharpType.GetUnionCases typeof<Generic<int>>).[0]
+
+    [<Test>]
+    let ``should construct Straightforward union case without arguments``() =
+        let ctor = FSharpValue.PreComputeUnionConstructorFast straightforwardCases.[0]
+        let resultObj = ctor [| |]
+        let result = resultObj :?> Straightforward
+        Assert.AreEqual(Empty, result)
+
+    [<Test>]
+    let ``should read Straightforward union case without arguments``() =
+        let dtor = FSharpValue.PreComputeUnionReaderFast straightforwardCases.[0]        
+        let result = dtor Empty
+        Assert.IsEmpty result
+
+    [<Test>]
+    let ``should construct Straightforward union case with one argument``() =
+        let ctor = FSharpValue.PreComputeUnionConstructorFast straightforwardCases.[1]
+        let resultObj = ctor [| "string" |]
+        let result = resultObj :?> Straightforward
+        Assert.AreEqual(S "string", result)
+
+    [<Test>]
+    let ``should read Straightforward union case with one argument``() =
+        let dtor = FSharpValue.PreComputeUnionReaderFast straightforwardCases.[1]    
+        let result = dtor (S "string")
+        Assert.AreEqual([| box "string" |], result)
+
+    [<Test>]
+    let ``should construct Straightforward union case with two arguments``() =
+        let ctor = FSharpValue.PreComputeUnionConstructorFast straightforwardCases.[2]
+        let resultObj = ctor [| 12; "string" |]
+        let result = resultObj :?> Straightforward
+        Assert.AreEqual(I (12,"string"), result)
+
+    [<Test>]
+    let ``should read Straightforward union case with two arguments``() =
+        let dtor = FSharpValue.PreComputeUnionReaderFast straightforwardCases.[2]    
+        let result = dtor (I (12,"string"))
+        Assert.AreEqual([| box 12; box "string" |], result)
+
+    [<Test>]
+    let ``should construct Singleton union case without arguments``() =
+        let ctor = FSharpValue.PreComputeUnionConstructorFast singletonCase
+        let resultObj = ctor [| |]
+        let result = resultObj :?> Singleton
+        Assert.AreEqual(Single, result)
+        Assert.AreSame(Single, result) //singletons union cases are singletons
+
+    [<Test>]
+    let ``should read Singleton union case without arguments``() =
+        let dtor = FSharpValue.PreComputeUnionReaderFast singletonCase
+        let result = dtor Single
+        Assert.IsEmpty result
+    
+    [<Test>]
+    let ``should construct Internal union case``() =
+        let ctor = FSharpValue.PreComputeUnionConstructorFast(internalCase, BindingFlags.NonPublic)
+        let resultObj = ctor [| "string" |]
+        let result = resultObj :?> Internal
+        Assert.AreEqual(Si "string", result)
+
+    [<Test>]
+    let ``should read Internal union case``() =
+        let dtor = FSharpValue.PreComputeUnionReaderFast(internalCase, BindingFlags.NonPublic)
+        let result = dtor (Si "string")
+        Assert.AreEqual([| box "string" |], result)
+
+    [<Test>]
+    let ``should not read Internal union case with BindingFlags.Public``() =
+        Assert.Throws<TargetInvocationException>(new TestDelegate(fun () -> FSharpValue.PreComputeUnionReaderFast(internalCase) |> ignore))
+        |> ignore
+
+    [<Test>]
+    let ``should construct Private union case``() =
+        let ctor = FSharpValue.PreComputeUnionConstructorFast(privateCase, BindingFlags.NonPublic)
+        let resultObj = ctor [| 1.23 |]
+        let result = resultObj :?> Private
+        Assert.AreEqual(Fp 1.23, result)
+
+    [<Test>]
+    let ``should read Private union case``() =
+        let dtor = FSharpValue.PreComputeUnionReaderFast(privateCase, BindingFlags.NonPublic)
+        let result = dtor (Fp 1.12)
+        Assert.AreEqual([| box 1.12 |], result)
+
+    [<Test>]
+    let ``should construct Generic union case``() =
+        let ctor = FSharpValue.PreComputeUnionConstructorFast genericCase
+        let resultObj = ctor [| 2 |]
+        let result = resultObj :?> Generic<int>
+        Assert.AreEqual(Generic 2, result)
+
+    [<Test>]
+    let ``should read Generic union case``() =
+        let dtor = FSharpValue.PreComputeUnionReaderFast genericCase       
+        let result = dtor (Generic 2)
+        Assert.AreEqual([| box 2 |], result)
+
+//make sure it is faster!
+module ReflectionPerformanceTest =
+
+    open NUnit.Framework
+    open Microsoft.FSharp.Reflection
+    open System.Reflection //for bindingflags
+
+    let [<Literal>] numRepeats = 400000
+    let [<Literal>] expectedImprovementTestor = 1L //conservative
+
+    type MyRecord =
+        { S : string
+          i : int
+          f : float }
+
+    let repeat f = 
+        let stopwatch = new System.Diagnostics.Stopwatch()
+        stopwatch.Start()
+        for i in 1..numRepeats do f i |> ignore
+        stopwatch.Stop()
+        stopwatch.ElapsedMilliseconds
+
+    let fastRecordCtor = FSharpValue.PreComputeRecordConstructorFast typeof<MyRecord>
+    let standardRecordCtor = FSharpValue.PreComputeRecordConstructor typeof<MyRecord>
+
+    let fastRecordReader = FSharpValue.PreComputeRecordReaderFast typeof<MyRecord>
+    let standardRecordReader = FSharpValue.PreComputeRecordReader typeof<MyRecord>
+
+    [<Test>]
+    let ``should construct record faster than F# reflection``() =
+        let fast = repeat (fun i -> fastRecordCtor [| "2"; i; 3. |] :?> MyRecord)
+        let standard = repeat (fun i -> standardRecordCtor [| "2"; i; 3. |] :?> MyRecord)
+        printf "FSharpx is %ix faster" (standard/fast)
+        Assert.True(fast < standard/expectedImprovementTestor)
+
+    [<Test>]
+    let ``should read record faster than F# reflection``() =
+        let fast = repeat (fun i -> fastRecordReader { S = "2"; i = i; f = 3.0 })
+        let standard = repeat (fun i -> standardRecordReader { S = "2"; i = i; f = 3.0 })
+        printf "FSharpx is %ix faster" (standard/fast)       
+        Assert.True(fast < standard/expectedImprovementTestor)
+
+    type MyUnion =
+        | Empty
+        | One of int
+        | Two of string * int
+
+    let unionCases = FSharpType.GetUnionCases typeof<MyUnion>
+
+    let fastUnionCtor = FSharpValue.PreComputeUnionConstructorFast unionCases.[2]
+    let standardUnionCtor = FSharpValue.PreComputeUnionConstructor unionCases.[2]
+
+    let fastUnionReader = FSharpValue.PreComputeUnionReaderFast unionCases.[2]
+    let standardUnionReader = FSharpValue.PreComputeUnionReader unionCases.[2]
+
+    [<Test>]
+    let ``should construct 2-case union faster than F# reflection``() =
+        let fast = repeat (fun i -> fastUnionCtor [| "3"; i |] :?> MyUnion)
+        let standard = repeat (fun i -> standardUnionCtor [| "3"; i |] :?> MyUnion)
+        printf "Fsharpx is %ix faster" (standard/fast)
+        Assert.True(fast < standard/expectedImprovementTestor)
+
+    [<Test>]
+    let ``should read 2-case union faster than F# reflection``() =
+        let fast = repeat (fun i -> fastUnionReader (Two ("s",i)))
+        let standard = repeat (fun i -> standardUnionReader (Two ("s",i)))
+        printf "FSharpx is %ix faster" (standard/fast)
+        Assert.True(fast < standard/expectedImprovementTestor)

--- a/src/FSharpx.Core/FSharpx.Core.fsproj
+++ b/src/FSharpx.Core/FSharpx.Core.fsproj
@@ -131,6 +131,7 @@
     <Compile Include="Async.IO.fs" />
     <Compile Include="Iteratee.fs" />
     <Compile Include="CSharpCompat.fs" />
+    <Compile Include="Reflection.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Core" Condition="$(TargetFrameworkVersion) == 'v3.5'">

--- a/src/FSharpx.Core/Reflection.fs
+++ b/src/FSharpx.Core/Reflection.fs
@@ -1,0 +1,109 @@
+﻿
+namespace FSharpx
+
+//This uses some simple dynamic IL generation,
+//and a clever technique desribed by Jon Skeet here:
+//https://msmvps.com/blogs/jon_skeet/archive/2008/08/09/making-reflection-fly-and-exploring-delegates.aspx
+module internal ReflectImpl =
+
+    open System
+    open System.Reflection
+    open Microsoft.FSharp.Reflection
+    open System.Reflection.Emit
+
+    let pushParams (generator:ILGenerator) (paramTypes:seq<Type>) =
+        let castFromObject typ =
+            if typ <> typeof<obj> then
+                if typ.IsValueType then
+                    generator.Emit(OpCodes.Unbox_Any, typ)
+                else
+                    generator.Emit(OpCodes.Castclass, typ)
+
+        paramTypes
+        |> Seq.iteri (fun i paramType -> 
+                        generator.Emit(OpCodes.Ldarg, 0)
+                        generator.Emit(OpCodes.Ldc_I4, i)
+                        generator.Emit(OpCodes.Ldelem_Ref)
+                        castFromObject paramType)     
+
+    
+    let preComputeRecordContructor(recordType:Type,bindingFlags:BindingFlags option) =
+        assert FSharpType.IsRecord(recordType, ?bindingFlags=bindingFlags)
+        let ctorInfo = FSharpValue.PreComputeRecordConstructorInfo(recordType,?bindingFlags=bindingFlags)
+        let meth = new DynamicMethod( "ctor", MethodAttributes.Static ||| MethodAttributes.Public,
+                                         CallingConventions.Standard, typeof<obj>, [| typeof<obj[]> |],
+                                         recordType,
+                                         true )
+        let generator = meth.GetILGenerator()
+        let paramTypes = ctorInfo.GetParameters() |> Seq.map (fun pi -> pi.ParameterType)
+    
+        let invoker =
+            pushParams generator paramTypes
+            generator.Emit(OpCodes.Newobj, ctorInfo)
+            generator.Emit(OpCodes.Ret)
+            meth.CreateDelegate(typeof<Func<obj[],obj>>) :?> Func<obj[],obj>
+        invoker.Invoke
+    
+    let preComputeUnionConstructor(unionCaseInfo:UnionCaseInfo, bindingFlags:BindingFlags option) =
+        let methodInfo = FSharpValue.PreComputeUnionConstructorInfo(unionCaseInfo, ?bindingFlags=bindingFlags)
+        let targetType = methodInfo.DeclaringType
+        assert FSharpType.IsUnion(targetType, ?bindingFlags=bindingFlags)
+        let meth = new DynamicMethod( "invoke", MethodAttributes.Static ||| MethodAttributes.Public,
+                                        CallingConventions.Standard, typeof<obj>,
+                                        [| typeof<obj[]> |], targetType, true )
+        let paramTypes = methodInfo.GetParameters() |> Seq.map (fun pi -> pi.ParameterType)
+        let generator = meth.GetILGenerator()
+
+        let invoker =
+            pushParams generator paramTypes
+            generator.Emit(OpCodes.Call, methodInfo)
+            generator.Emit(OpCodes.Ret)
+            meth.CreateDelegate(typeof<Func<obj[],obj>>) :?> Func<obj[],obj>
+
+        invoker.Invoke
+
+    type Marker = class end
+    let getter<'Target, 'Return> (methodInfo:MethodInfo) =
+         let del = Delegate.CreateDelegate(typeof<Func<'Target,'Return>>, methodInfo) :?> Func<'Target,'Return>
+         fun target -> box <| del.Invoke(unbox target)
+    let getterMethodInfo = typeof<Marker>.DeclaringType.GetMethod("getter",BindingFlags.Static ||| BindingFlags.NonPublic)
+
+    let preComputeFieldReader (nonPublic:bool) (propertyInfo:PropertyInfo) :(obj -> obj) =
+        let getMethod = propertyInfo.GetGetMethod(nonPublic)
+        let target = propertyInfo.DeclaringType
+        let returnType = propertyInfo.PropertyType
+        let toInvoke = getterMethodInfo.MakeGenericMethod([| target; returnType |])
+        let getter = toInvoke.Invoke(null, [| getMethod |]) 
+        getter :?> (obj -> obj)
+
+    let wantNonPublic bindingFlags =
+        let bindingFlags = defaultArg bindingFlags BindingFlags.Public
+        bindingFlags &&& BindingFlags.NonPublic = BindingFlags.NonPublic
+
+    let preComputeFieldsReader fields bindingFlags =
+        let readers = fields |> Array.map (preComputeFieldReader (wantNonPublic bindingFlags))
+        fun (target:obj) -> readers |> Array.map ((|>) target)
+
+    let preComputeRecordReader (recordType:Type, bindingFlags:BindingFlags option) =
+        let fields = FSharpType.GetRecordFields(recordType, ?bindingFlags=bindingFlags)
+        preComputeFieldsReader fields bindingFlags
+
+    let preComputeUnionReader(unionCase:UnionCaseInfo, bindingFlags:BindingFlags option) =
+        let fields = unionCase.GetFields()
+        preComputeFieldsReader fields bindingFlags
+
+namespace Microsoft.FSharp.Reflection
+
+open System
+open System.Reflection
+
+type FSharpValue =
+    static member PreComputeRecordConstructorFast(recordType:Type,?bindingFlags:BindingFlags) =
+        FSharpx.ReflectImpl.preComputeRecordContructor(recordType,bindingFlags)
+    static member PreComputeUnionConstructorFast(unionCase:UnionCaseInfo, ?bindingFlags:BindingFlags) =
+        FSharpx.ReflectImpl.preComputeUnionConstructor(unionCase,bindingFlags)
+    static member PreComputeRecordReaderFast(recordType:Type, ?bindingFlags:BindingFlags) : obj -> obj[] =
+        FSharpx.ReflectImpl.preComputeRecordReader(recordType,bindingFlags)
+    static member PreComputeUnionReaderFast(unionCase:UnionCaseInfo, ?bindingFlags:BindingFlags) : obj -> obj[] =
+        FSharpx.ReflectImpl.preComputeUnionReader(unionCase, bindingFlags)
+


### PR DESCRIPTION
The fast reflection operations (relative to the equivalent operations in
FSharp.Core) are the four FSsharpValue.PreCompute___Fast  members for
constructing and reading record types or union types.

I used type augmentation to add the differently named members to Microsoft.Reflection.FSharpValue. Feel free to change that if you don't like it. (I missed @dsyme's last comment in the issue until just now...)

https://github.com/fsharp/fsharpx/issues/234
