### PR TITLE
optimized "init" and "create"

### DIFF
--- a/src/FSharpx.Core/Collections/ResizeArray.fs
+++ b/src/FSharpx.Core/Collections/ResizeArray.fs
@@ -14,8 +14,15 @@ module ResizeArray =
     let length (arr: ResizeArray<'T>) =  arr.Count
     let get (arr: ResizeArray<'T>) (n: int) =  arr.[n]
     let set (arr: ResizeArray<'T>) (n: int) (x:'T) =  arr.[n] <- x
-    let create  (n: int) x = new ResizeArray<_> (seq { for _ in 1 .. n -> x })
-    let init (n: int) (f: int -> 'T) =  new ResizeArray<_> (seq { for i in 0 .. n-1 -> f i })
+    let create  (n: int) x = 
+        let arr = ResizeArray<_>(n)
+        for i=0 to n-1 do arr.Add x
+        arr
+    
+    let init (n: int) (f: int -> 'T) =  
+        let arr = ResizeArray<_>(n)
+        for i=0 to n-1 do arr.Add (f i)
+        arr
 
     let blit (arr1: ResizeArray<'T>) start1 (arr2: ResizeArray<'T>) start2 len =
         if start1 < 0 then invalidArg "start1" "index must be positive"


### PR DESCRIPTION
this versions of "init" without the seq expression runs about 15 times faster for me. my comparison:
is there a reason to not do it like this ?
# time

let createSeq n x = new ResizeArray<_> (seq { for _ in 1 .. n -> x })

let createLoop (n: int) x = 
    let arr = ResizeArray<_>(n)
    for i=0 to n-1 do arr.Add x
    arr

for i=0 to 1000 do  // Real: 00:00:00.506, CPU: 00:00:00.530, GC Gen0: 14, Gen1: 3, Gen2: 3
    let r = createSeq 1000 4.4
    r.Count |> ignore

for i=0 to 1000 do // Real: 00:00:00.016, CPU: 00:00:00.031, GC Gen0: 1, Gen1: 1, Gen2: 1
    let r = createLoop 1000 4.4
    r.Count |> ignore
