### PR TITLE
Add Async and AsyncBuilder extensions for working with non-generic Tasks

### DIFF
--- a/src/FSharpx.Core/Async.fs
+++ b/src/FSharpx.Core/Async.fs
@@ -60,7 +60,7 @@ module AsyncExtensions =
     /// 'Bind' of the 'async' builder. The new overload awaits on 
     /// a standard .NET task
     type Microsoft.FSharp.Control.AsyncBuilder with
-        member x.Bind(t:Tasks.Task<'T>, f:'T -> Async<'R>) : Async<'R>   = async.Bind(Async.AwaitTask t, f)
-        member x.Bind(t:Tasks.Task, f:unit -> Async<unit>) : Async<unit> = async.Bind(Async.AwaitTask t, f)
+        member x.Bind(t:Tasks.Task<'T>, f:'T -> Async<'R>) : Async<'R> = async.Bind(Async.AwaitTask t, f)
+        member x.Bind(t:Tasks.Task, f:unit -> Async<'R>)   : Async<'R> = async.Bind(Async.AwaitTask t, f)
 
 #endif


### PR DESCRIPTION
I went looking to add `Task` support to the `AsyncBuilder` and was pleasantly surprised to find it in the source for generic `Task<'T>`s. However, the bigger headache tends to come from `Task`. This commit adds that support.
