### PR TITLE
Update FSharpx.Core.Tests.fsproj to build on Mac and on Windows with msbuild

### DIFF
--- a/FSharpx.Core.Tests/FSharpx.Core.Tests.fsproj
+++ b/FSharpx.Core.Tests/FSharpx.Core.Tests.fsproj
@@ -34,7 +34,19 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\FSharpx.Core.Tests.XML</DocumentationFile>
   </PropertyGroup>
-  <Import Project="..\lib\FSharp\Microsoft.FSharp.Targets" />
+  <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets') And $(TargetFramework) != 'portable47'">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets') And $(TargetFramework) != 'portable47'">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.Portable.FSharp.Targets') And $(TargetFramework) == 'portable47'">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="Exists('$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.Portable.FSharp.Targets') And $(TargetFramework) == 'portable47'">
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.1\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+  </PropertyGroup>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <ItemGroup>
     <Reference Include="FsUnit.NUnit">
       <HintPath>..\packages\FsUnit.1.2.1.0\Lib\Net40\FsUnit.NUnit.dll</HintPath>


### PR DESCRIPTION
Building on OS X I get the following error:

```
    /Users/Patrick/Projects/FSharp/fsharpx/FSharpx.Core.Tests/FSharpx.Core.Tests.fsproj: error : 
/Users/Patrick/Projects/FSharp/fsharpx/FSharpx.Core.Tests/FSharpx.Core.Tests.fsproj: 
/Users/Patrick/Projects/FSharp/fsharpx/FSharpx.Core.Tests/FSharpx.Core.Tests.fsproj could not import 
"..\lib\FSharp\Microsoft.FSharp.Targets"
```

Also building on Windows with MSBuild I get the same error:

```
"C:\Projects\fsharpx\FSharpx.sln" (default target) (1) ->
"C:\Projects\fsharpx\FSharpx.Core.Tests\FSharpx.Core.Tests.fsproj" (default target) (14) ->
  C:\Projects\fsharpx\FSharpx.Core.Tests\FSharpx.Core.Tests.fsproj(37,3): error MSB4019: The imported project 
"C:\Projects\fsharp x\lib\FSharp\Microsoft.FSharp.Targets" was not found. Confirm that the path in the 
<Import> declaration is correct, and that the file exists on disk.
```
