### PR TITLE
Fix nuget link

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -16,7 +16,7 @@ let info =
     "project-author", "Steffan Forkmann and others"
     "project-summary", "Extra components for FSharpx"
     "project-github", githubLink
-    "project-nuget", "http://nuget.com/packages/FSharpx.Core" ]
+    "project-nuget", "http://nuget.org/packages/FSharpx.Core" ]
 
 // --------------------------------------------------------------------------------------
 // For typical project, no changes are needed below


### PR DESCRIPTION
Was pointing to nuget.com instead of nuget.org
