### PR TITLE
Enum convenience methods

### DIFF
--- a/src/FSharpx.Extras/Enum.fs
+++ b/src/FSharpx.Extras/Enum.fs
@@ -1,0 +1,15 @@
+﻿namespace FSharpx
+open System.Linq
+
+module Enum=
+    let tryParse s :'a option when 'a:enum<'b> =
+        match System.Enum.TryParse (s) with
+        | true, v -> Some v
+        | _ -> None
+        
+    let parse s : 'a =
+        System.Enum.Parse(typeof<'a>, s) :?> 'a
+
+    let getValues<'t> ()= 
+        let values = System.Enum.GetValues (typeof<'t>) 
+        Enumerable.Cast<'t> values //Array.unbox

--- a/src/FSharpx.Extras/FSharpx.Extras.fsproj
+++ b/src/FSharpx.Extras/FSharpx.Extras.fsproj
@@ -86,6 +86,7 @@
     <Content Include="app.config" />
     <Compile Include="Net.fs" />
     <Compile Include="Conneg.fs" />
+    <Compile Include="Enum.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.Control.AsyncSeq">

--- a/tests/FSharpx.Tests/EnumTest.fs
+++ b/tests/FSharpx.Tests/EnumTest.fs
@@ -1,0 +1,26 @@
+﻿module FSharpx.Http.Tests.EnumTests
+open NUnit.Framework
+open FSharpx
+
+type LanguageOptions=
+    | FSharp = 0
+    | CSharp = 1
+    | VB = 2
+    
+[<Test>] 
+let ``tryParse can parse value and return Some value`` ()=
+    Assert.AreEqual(Some LanguageOptions.CSharp, (Enum.tryParse("CSharp") : LanguageOptions option))
+
+[<Test>] 
+let ``tryParse returns None if it fails to parse`` ()=
+    Assert.AreEqual(None, (Enum.tryParse("English") : LanguageOptions option))
+
+[<Test>] 
+let ``parse returns parsed value`` ()=
+    Assert.AreEqual(LanguageOptions.CSharp ,(Enum.parse("CSharp") : LanguageOptions))
+
+let ``parse throws an exception when it fails to parse`` ()=
+    let parseEnglish ()=
+        let x = Enum.parse("English") : LanguageOptions
+        ()
+    Assert.Throws<System.Exception>( TestDelegate( parseEnglish ) )  

--- a/tests/FSharpx.Tests/FSharpx.Tests.fsproj
+++ b/tests/FSharpx.Tests/FSharpx.Tests.fsproj
@@ -95,6 +95,7 @@
     <Compile Include="ControlTests.fs" />
     <Compile Include="AsyncStreamReaderTest.fs" />
     <Compile Include="ConnegTests.fs" />
+    <Compile Include="EnumTest.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FsCheck">


### PR DESCRIPTION
In order to write more f#-like code when dealing with enums.