### PR TITLE
Bugfix for loops in the maybe computation expression

### DIFF
--- a/src/FSharpx.Extras/ComputationExpressions/Monad.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Monad.fs
@@ -116,8 +116,9 @@ module Option =
             this.TryFinally(body res, fun () -> match res with null -> () | disp -> disp.Dispose())
 
         member this.While(guard, f) =
-            if not (guard()) then this.Zero() else
-            this.Bind(f(), fun _ -> this.While(guard, f))
+            if not (guard()) then Some () else
+            do f() |> ignore
+            this.While(guard, f)
 
         member this.For(sequence:seq<_>, body) =
             this.Using(sequence.GetEnumerator(),

--- a/tests/FSharpx.Tests/MaybeTest.fs
+++ b/tests/FSharpx.Tests/MaybeTest.fs
@@ -80,3 +80,27 @@ let ``monadplus laws``() =
         fun a b -> mplus (ret a) b = ret a
 //    fsCheck "left distribution" <|
 //        fun a b f -> (mplus a b >>= f) = (mplus (a >>= f) (b >>= f))
+
+[<Test>]
+let ``for loops enumerate entire sequence and subsequent expressions also run``() =
+    let count = ref 0
+    let result = maybe {
+        for i in [1;2;3] do
+            incr count
+        return true
+    }
+
+    !count |> should equal 3
+    result |> should equal (Some true)
+
+[<Test>]
+let ``while loops execute until guard is false and subsequent expressions also run``() =
+    let count = ref 0
+    let result = maybe {
+        while !count < 3 do
+            incr count
+        return true
+    }
+
+    !count |> should equal 3
+    result |> should equal (Some true)


### PR DESCRIPTION
One would expect that with the following code snippet:

```fsharp
let count = ref 0
let result = maybe {
    for i in [1;2;3] do
       incr count
   return true
}
```
`count` would be `3` and `result` would be `Some true`. Unfortunately, `count` will actually be `1` and `result` will be `None`.

This is due to the implementation of `While` in the maybe computation expression, which binds against the return value of the body of the for (or while) loop. Because for and while loop bodies are side-effects (ie. they must return unit), they will always return `Zero` (`None`). This causes the loop to not continue, since `Bind` is used on that return value, and that return value is always `None`.

In addition, when the `guard` returns false (at the end of the enumeration), `While` returns Zero (None), which effectively cancels the rest of the computation expression.

I've reimplemented `While` to recur until the guard returns false, executing the body expression and _ignoring_ its result (as it will always be `Zero`). When the `guard` is false, it now returns `Some ()`, which will cause the computation expression to keep evaluating (because it's `Some`) and since the whole loop structure is a big side effect, the appropriate value inside the option is `unit`.

I've added a couple of tests to verify this behaviour.