### PR TITLE
Add ofOptionF to Result module

### DIFF
--- a/src/FSharpx.Extras/ComputationExpressions/Result.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Result.fs
@@ -71,6 +71,12 @@ module Result =
         | Some a -> Ok a
         | None -> Error o
 
+    /// If Some value, returns Ok value. Otherwise, returns the supplied default value from a function.
+    let ofOptionF f =
+        function
+        | Some a -> Ok a
+        | None -> Error (f())
+
     let inline sequence s =
         let inline cons a b = lift2 List.cons a b
         List.foldBack cons s (returnM [])

--- a/tests/FSharpx.Tests/FSharpx.Tests.fsproj
+++ b/tests/FSharpx.Tests/FSharpx.Tests.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="OptionTests.fs" />
     <Compile Include="ChoiceTests.fs" />
     <Compile Include="ResultTests.fs" />
+    <Compile Include="ResultOfOptionTests.fs" />
     <Compile Include="PreludeTests.fs" />
     <Compile Include="LensTests.fs" />
     <Compile Include="LensExample.fs" />

--- a/tests/FSharpx.Tests/ResultOfOptionTests.fs
+++ b/tests/FSharpx.Tests/ResultOfOptionTests.fs
@@ -1,0 +1,31 @@
+module FSharpx.Tests.ResultOfOptionTests
+
+open NUnit.Framework
+open FSharpx
+
+let equals expected actual =
+    if expected <> actual then Assert.Fail(sprintf "Expected %A to equal %A" actual expected)
+
+[<Test>]
+let ``can create Ok from ofOption``() =
+  Some "Success"
+  |> Result.ofOption ""
+  |> equals (Ok "Success")
+
+[<Test>]
+let ``can create Error from ofOption``() =
+  None
+  |> Result.ofOption "Failure"
+  |> equals (Error "Failure")
+
+[<Test>]
+let ``can create Ok from ofOptionF``() =
+  Some "Success"
+  |> Result.ofOptionF (fun () -> "")
+  |> equals (Ok "Success")
+
+[<Test>]
+let ``can create Error from ofOptionF``() =
+  None
+  |> Result.ofOptionF (fun () -> "Failure")
+  |> equals (Error "Failure")


### PR DESCRIPTION
Add Result.ofOptionF in order to create a result from an option using a
function to supply the default value.
Using a function enables the error object to be resolved when needed
instead of up-front.