### PR TITLE
Adding a new function to Enum module (isDefined)

### DIFF
--- a/src/FSharpx.Extras/Enum.fs
+++ b/src/FSharpx.Extras/Enum.fs
@@ -13,3 +13,13 @@ module Enum=
     let getValues<'t> ()= 
         let values = System.Enum.GetValues (typeof<'t>) 
         Enumerable.Cast<'t> values //Array.unbox
+
+    /// From http://www.fssnip.net/4V/title/Check-if-value-is-a-valid-enum-or-flags-combination
+    [<CompiledName("IsDefined")>]
+    let isDefined<'a, 'b when 'a : enum<'b>> (value:'a) =
+        let (!<) = box >> unbox >> uint64
+        let typ = typeof<'a>
+        if typ.IsDefined(typeof<System.FlagsAttribute>, false)
+            then (!< value, System.Enum.GetValues(typ) |> unbox)
+                 ||> Array.fold (fun n v -> n &&& ~~~(!< v)) = 0UL
+            else System.Enum.IsDefined(typ, value)

--- a/tests/FSharpx.Tests/EnumTest.fs
+++ b/tests/FSharpx.Tests/EnumTest.fs
@@ -24,3 +24,27 @@ let ``parse throws an exception when it fails to parse`` ()=
         let x = Enum.parse("English") : LanguageOptions
         ()
     Assert.Throws<System.Exception>( TestDelegate( parseEnglish ) )  
+
+[<Test>] 
+let ``isDefined returns true when valid simple enum value is checked`` ()=
+    Assert.IsTrue(Enum.isDefined LanguageOptions.CSharp && Enum.isDefined LanguageOptions.FSharp && Enum.isDefined LanguageOptions.VB)
+
+[<Test>] 
+let ``isDefined returns false when not valid simple enum value is checked`` ()=
+    let invalidEnum : LanguageOptions = enum 3
+    Assert.IsFalse(Enum.isDefined invalidEnum)
+
+[<System.Flags>]
+type FlaggedLanguageOptions =
+    | FSharp = 0
+    | CSharp = 1
+    | VB = 2
+
+[<Test>] 
+let ``isDefined returns true when valid flagged enum value is checked`` ()=
+    Assert.IsTrue(Enum.isDefined (FlaggedLanguageOptions.CSharp ||| FlaggedLanguageOptions.FSharp ||| FlaggedLanguageOptions.VB))
+
+[<Test>] 
+let ``isDefined returns false when not valid flagged enum value is checked`` ()=
+    let invalidEnum : FlaggedLanguageOptions = enum 300
+    Assert.IsFalse(Enum.isDefined invalidEnum)


### PR DESCRIPTION
When working with Enums in F#, I think it's interesting to have a function that checks if an Enum value is  a valid Enum, specially for Flagged Enums. Searching I found this snippet (http://www.fssnip.net/4V/title/Check-if-value-is-a-valid-enum-or-flags-combination) and I think it would be interesting to be added in this library.

I added some tests using it.

Thank you