### PR TITLE
Add Option.ofUnchecked function

### DIFF
--- a/src/FSharpx.Extras/ComputationExpressions/Option.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Option.fs
@@ -135,9 +135,9 @@ module Option =
     /// Maps Unchecked object when null to None, otherwise Some value.
     /// It's useful when getting data from external sources, pe.
     let inline ofUnchecked (x: 'a when 'a : not struct) =
-        match box x = null with
-        | true -> None
-        | false -> Some x
+        match box x with
+        | null -> None
+        | _ -> Some x
 
     /// Gets the value associated with the option or the supplied default value.
     let inline getOrElse v =

--- a/src/FSharpx.Extras/ComputationExpressions/Option.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Option.fs
@@ -132,6 +132,12 @@ module Option =
         | Ok a -> Some a
         | _ -> None
 
+    /// Maps Unchecked object when null to None, otherwise Some value.
+    /// It's useful when getting data from external sources, pe.
+    let ofUnchecked (x: 'a) =
+        match Unchecked.defaultof<'a> = x with
+        | true -> None
+        | false -> Some x
 
     /// Gets the value associated with the option or the supplied default value.
     let inline getOrElse v =

--- a/src/FSharpx.Extras/ComputationExpressions/Option.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Option.fs
@@ -134,8 +134,8 @@ module Option =
 
     /// Maps Unchecked object when null to None, otherwise Some value.
     /// It's useful when getting data from external sources, pe.
-    let ofUnchecked (x: 'a) =
-        match Unchecked.defaultof<'a> = x with
+    let inline ofUnchecked (x: 'a when 'a : not struct) =
+        match box x = null with
         | true -> None
         | false -> Some x
 

--- a/tests/FSharpx.Tests/OptionTests.fs
+++ b/tests/FSharpx.Tests/OptionTests.fs
@@ -94,3 +94,12 @@ let someIfBoolTestCases = [
 [<TestCaseSource(nameof someIfBoolTestCases)>]
 let ``someIf with id`` (input:bool, expectedOutput:bool option) =
     Option.someIf id input |> shouldEqual expectedOutput
+
+type UncheckedRecordTest =
+    { Dummy: int }
+
+[<Test>]
+let ``from unchecked value``() =
+    let test = { Dummy = 4 }
+    Assert.AreEqual(Some test, Option.ofUnchecked test)
+    Assert.AreEqual(None, Option.ofUnchecked (Unchecked.defaultof<UncheckedRecordTest>))

--- a/tests/FSharpx.Tests/OptionTests.fs
+++ b/tests/FSharpx.Tests/OptionTests.fs
@@ -103,3 +103,13 @@ let ``from unchecked value``() =
     let test = { Dummy = 4 }
     Assert.AreEqual(Some test, Option.ofUnchecked test)
     Assert.AreEqual(None, Option.ofUnchecked (Unchecked.defaultof<UncheckedRecordTest>))
+
+[<NoEquality;NoComparison>] 
+type UncheckedRecordTest2 =
+    { Dummy2: int }
+
+[<Test>]
+let ``from unchecked value without equality nor comparison``() =
+    let test = { Dummy2 = 4 }
+    Assert.AreEqual(Some test, Option.ofUnchecked test)
+    Assert.AreEqual(None, Option.ofUnchecked (Unchecked.defaultof<UncheckedRecordTest2>))


### PR DESCRIPTION
I use this function vastly when getting data from external sources like DB. You can define a Record that, in **F#**, "cannot be null" but when you are getting data from DB using tools like **Dapper**, qhen you do an action like "**FirstOrDefault**" from a **Record**, when "**Default**", it generates a null Record. That null Record cannot be converted "easily" to option because compiler says that "Record = null" cannot compile. So it's required to check with **Unchecked.defaultof<Record>** to see if it's null (or **box it** to see if obj is null).