### PR TITLE
Allow not null implementation of IDisposable in CEs

### DIFF
--- a/src/FSharpx.Extras/ComputationExpressions/Continuation.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Continuation.fs
@@ -42,7 +42,7 @@ module Continuation =
             this.Bind(this.Catch tryBlock, (function Choice1Of2 v -> finallyBlock(); this.Return v 
                                                    | Choice2Of2 exn -> finallyBlock(); throw exn))
         member this.Using(res:#IDisposable, body) =
-            this.TryFinally(body res, (fun () -> match res with null -> () | disp -> disp.Dispose()))
+            this.TryFinally(body res, fun () -> if not (isNull (box res)) then res.Dispose())
         member this.Combine(comp1, comp2) = this.Bind(comp1, (fun () -> comp2))
         member this.Delay(f) = this.Bind(this.Return (), f)
         member this.While(pred, body) =

--- a/src/FSharpx.Extras/ComputationExpressions/Option.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Option.fs
@@ -31,7 +31,7 @@ module Option =
             finally compensation()
 
         member this.Using(res:#IDisposable, body) =
-            this.TryFinally(body res, fun () -> match res with null -> () | disp -> disp.Dispose())
+            this.TryFinally(body res, fun () -> if not (isNull (box res)) then res.Dispose())
 
         member this.While(guard, f) =
             if not (guard()) then Some () else

--- a/src/FSharpx.Extras/ComputationExpressions/Reader.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Reader.fs
@@ -23,7 +23,7 @@ module Reader =
             fun env -> try m env
                        finally compensation()
         member this.Using(res:#IDisposable, body) =
-            this.TryFinally(body res, (fun () -> match res with null -> () | disp -> disp.Dispose()))
+            this.TryFinally(body res, fun () -> if not (isNull (box res)) then res.Dispose())
         member this.Delay(f) = this.Bind(this.Return (), f)
         member this.While(guard, m) =
             if not(guard()) then this.Zero() else

--- a/src/FSharpx.Extras/ComputationExpressions/State.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/State.fs
@@ -30,7 +30,7 @@ module State =
             fun env -> try m env
                        finally compensation()
         member this.Using(res:#IDisposable, body) =
-            this.TryFinally(body res, (fun () -> match res with null -> () | disp -> disp.Dispose()))
+            this.TryFinally(body res, fun () -> if not (isNull (box res)) then res.Dispose())
         member this.Delay(f) = this.Bind(this.Return (), f)
         member this.While(guard, m) =
             if not(guard()) then this.Zero() else

--- a/src/FSharpx.Extras/ComputationExpressions/Task.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Task.fs
@@ -147,12 +147,7 @@ module Task =
             this.Bind(this.TryWith(body, wrapCrash), wrapOk)
 
         member this.Using(res:#IDisposable, body : #IDisposable -> Task<'a>) : Task<'a> =
-            let compensation() =
-                match res with
-                | null -> ()
-                | disp -> disp.Dispose()
-
-            this.TryFinally((fun () -> body res), compensation)
+            this.TryFinally((fun () -> body res), fun () -> if not (isNull (box res)) then res.Dispose())
 
         member this.For(sequence:seq<'a>, body : 'a -> Task<unit>) : Task<unit> =
             this.Using( sequence.GetEnumerator()

--- a/src/FSharpx.Extras/ComputationExpressions/Writer.fs
+++ b/src/FSharpx.Extras/ComputationExpressions/Writer.fs
@@ -29,8 +29,8 @@ module Writer =
         member this.TryFinally(writer, compensation) =
             fun () -> try writer()
                       finally compensation()
-        member this.Using<'d,'W,'T when 'd :> IDisposable and 'd : null>(resource : 'd, body : 'd -> Writer<'W,'T>) : Writer<'W,'T> =
-            this.TryFinally(body resource, fun () -> match resource with null -> () | disp -> disp.Dispose())
+        member this.Using(resource: #IDisposable, body) =
+            this.TryFinally(body resource, fun () -> if not (isNull (box resource)) then resource.Dispose())
         member this.Combine(comp1, comp2) = this.Bind(comp1, fun () -> comp2)
         member this.Delay(f) = this.Bind(this.Return (), f)
         member this.While(guard, m) =

--- a/tests/FSharpx.Tests/ContinuationTest.fs
+++ b/tests/FSharpx.Tests/ContinuationTest.fs
@@ -6,6 +6,7 @@ open FSharpx.Functional
 open FSharpx.Continuation
 open NUnit.Framework
 open FsUnit
+open TestHelpers
 
 let c n = cont { return n }
 let addSomeNumbers = cont {
@@ -62,3 +63,17 @@ let ``When running a coroutine it should yield elements in turn``() =
   })
   coroutine.Run()
   actual.ToString() |> should equal "A1B2C"
+
+[<Test>]
+let ``use should dispose underlying IDisposable``() =
+  let disposeChecker = new DisposeChecker()
+  let r =
+     cont {
+       use! x = c disposeChecker
+       return x.Disposed
+     }
+  Assert.Multiple
+    (fun () ->
+      runCont r id raise |> shouldEqual false
+      disposeChecker.Disposed |> shouldEqual true
+    )

--- a/tests/FSharpx.Tests/ReaderTest.fs
+++ b/tests/FSharpx.Tests/ReaderTest.fs
@@ -7,6 +7,7 @@ open FSharpx.Functional
 open FSharpx.Reader
 open NUnit.Framework
 open FsUnit
+open TestHelpers
 
 // Basic monadic builder tests.
 [<Test>]
@@ -116,3 +117,17 @@ let ``for should increment count``() =
       incr count }
   r ()
   !count |> should equal 2
+
+[<Test>]
+let ``use should dispose underlying IDisposable``() =
+  let disposeChecker = new DisposeChecker()
+  let r =
+     (reader {
+       use! x = reader {return disposeChecker}
+       return x.Disposed
+     })()
+  Assert.Multiple
+    (fun () ->
+      disposeChecker.Disposed |> shouldEqual true
+      r |> shouldEqual false
+    )

--- a/tests/FSharpx.Tests/StateTest.fs
+++ b/tests/FSharpx.Tests/StateTest.fs
@@ -4,6 +4,7 @@ open FSharpx
 open FSharpx.State
 open NUnit.Framework
 open FsUnit
+open TestHelpers
 
 // Simple example
 let tick = state {
@@ -39,3 +40,17 @@ let workflow = state {
 [<Test>]
 let ``When running the workflow, it should return 4``() =
   eval workflow [] |> should equal 4
+
+[<Test>]
+let ``use should dispose underlying IDisposable``() =
+  let disposeChecker = new DisposeChecker()
+  let r =
+     state {
+       use! x = state { return disposeChecker }
+       return x.Disposed
+     }
+  Assert.Multiple
+    (fun () ->
+      eval r () |> shouldEqual false
+      disposeChecker.Disposed |> shouldEqual true
+    )

--- a/tests/FSharpx.Tests/TaskTests.fs
+++ b/tests/FSharpx.Tests/TaskTests.fs
@@ -5,6 +5,8 @@ open System
 open System.IO
 open System.Net
 open NUnit.Framework
+open FsUnitTyped
+open TestHelpers
 open FSharpx
 open FSharpx.Functional
 open System.Threading
@@ -210,3 +212,17 @@ let ``run delay law``() =
     let run (transform : _ -> Task<_>) t = (transform t).Result
 
     fsCheck "run delay law" (fun t -> run id t = run delay t)
+
+[<Test>]
+let ``use should dispose underlying IDisposable``() =
+    let disposeChecker = new DisposeChecker()
+    let r =
+        Task.task {
+            use! x = Task.task {return disposeChecker}
+            return x.Disposed
+        }
+    Assert.Multiple
+        (fun () ->
+            (r.Result) |> shouldEqual false
+            disposeChecker.Disposed |> shouldEqual true
+        )

--- a/tests/FSharpx.Tests/WriterTest.fs
+++ b/tests/FSharpx.Tests/WriterTest.fs
@@ -4,6 +4,7 @@ open FSharpx
 open FSharpx.Writer
 open NUnit.Framework
 open FsUnit
+open TestHelpers
 
 let logMsg (message:string) = tell [message]
 let processFile file = printfn "%s" file
@@ -27,4 +28,17 @@ let ``When processing files, it should log messages``() =
                                          "Processing C:\Test1.txt"
                                          "Processing C:\Test2.txt"
                                          "End processing files"])
-    
+
+[<Test>]
+let ``use should dispose underlying IDisposable``() =
+  let disposeChecker = new DisposeChecker()
+  let (r,_) =
+     (writer {
+       use! x = writer {return disposeChecker}
+       return x.Disposed
+     })()
+  Assert.Multiple
+    (fun () ->
+      disposeChecker.Disposed |> shouldEqual true
+      r |> shouldEqual false
+    )


### PR DESCRIPTION
Current implementation backing `use!` in most of the CEs for the `IDisposable` implementing type to be null allowing. This is an artificial requirement which limits the usefulness of the code.

This PR amends the implementations to allow type for which null is not a valid value.