### PR TITLE
Unignore tests

### DIFF
--- a/src/FSharpx.Extras/FSharpx.Extras.fsproj
+++ b/src/FSharpx.Extras/FSharpx.Extras.fsproj
@@ -5,10 +5,7 @@
     <RootNamespace>FSharpx</RootNamespace>
     <AssemblyName>FSharpx.Extras</AssemblyName>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <Optimize>true</Optimize>
-    <Tailcalls>true</Tailcalls>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/FSharpx.Extras/Monoid.fs
+++ b/src/FSharpx.Extras/Monoid.fs
@@ -166,6 +166,6 @@ namespace FSharpx.Collections
     module ByteString = 
         let monoid =
             { new Monoid<_>() with
-                override x.Zero() = ByteString.empty
+                override x.Zero() = ByteString([||],0,0)
                 override x.Combine(a,b) = ByteString.append a b }
 

--- a/tests/FSharpx.Tests/MonoidTests.fs
+++ b/tests/FSharpx.Tests/MonoidTests.fs
@@ -11,7 +11,7 @@ open FSharpx.Tests.Properties
 open FSharpx.Monoid
 
 type ByteStringGen =
-    static member ByteStringArb =
+    static member ByteStringArb() =
         let g = gen {
             let! a = Arb.generate<_[]>
             let! offset = Gen.choose(0, max 0 (a.Length - 1))
@@ -20,7 +20,9 @@ type ByteStringGen =
         }
         Arb.fromGen g
 
-let bytestringArbRegister = lazy (FsCheck.Arb.register<ByteStringGen>() |> ignore)
+[<OneTimeSetUp>]
+let setup() =
+    Arb.register<ByteStringGen>() |> ignore
 
 [<Test>]
 let ``int product monoid``() =
@@ -82,9 +84,7 @@ let ``max monoid``() =
     checkMonoid "max" Monoid.maxInt
 
 [<Test>]
-[<Ignore("Ignore temporarily this test")>]
 let ``bytestring monoid``() =
-    bytestringArbRegister.Force()
     checkMonoid "bytestring" ByteString.monoid
 
 [<Test>]

--- a/tests/FSharpx.Tests/StringsTest.fs
+++ b/tests/FSharpx.Tests/StringsTest.fs
@@ -95,12 +95,11 @@ baz
 
     a |> toLines |> shouldEqual expected
 
-[<Test; Ignore("Failing on appveyor due to line endings")>]
+[<Test>]
 let ``Should merge by newlines`` () = 
     let a = ["foo biz";"bar";"baz"]
-    let expected = @"foo biz
-bar
-baz"   
+    let osSpecificNewLine = System.Environment.NewLine
+    let expected = sprintf "foo biz%sbar%sbaz" osSpecificNewLine osSpecificNewLine
 
     a |> joinLines |> shouldEqual expected
 


### PR DESCRIPTION
* Fix ByteString monoid by working around FSharpx.Collections ByteString.empty bug
* Fix debug config by turning off tail calls and optimizations